### PR TITLE
fix cause rendering parallel segment

### DIFF
--- a/.changeset/bright-flowers-study.md
+++ b/.changeset/bright-flowers-study.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Fix Cause Rendering

--- a/src/internal/cause.ts
+++ b/src/internal/cause.ts
@@ -1336,9 +1336,14 @@ const format = (segment: Segment): ReadonlyArray<Doc.Doc<never>> => {
       const verticalSeparator = Doc.cat(box.vertical.heavy)(spaces)
 
       const junction = Doc.cat(box.branch.down.heavy)(horizontalLines)
-      const busTerminal = Doc.cat(box.terminal.down.heavy)(horizontalLines)
 
-      const fiberBus = Doc.hcat([...times(junction, segment.all.length - 1), busTerminal])
+      const fiberBus = Doc.hcat([
+        ...times(junction, segment.all.length - 1),
+        box.horizontal.heavy,
+        box.horizontal.heavy,
+        box.terminal.down.heavy
+      ])
+
       const segments = segment.all.reduceRight(
         (acc, curr) => [
           ...prefixBlock(acc, verticalSeparator, verticalSeparator),


### PR DESCRIPTION
```bash
gitpod /workspace/io (main) $ pnpm run example examples/defects.ts 

> @effect/io@0.0.5 example /workspace/io
> ts-node --project tsconfig.examples.json "examples/defects.ts"


╥
║
╠══╦══╗
║  ║  ║
║  ║  ╠─A checked error was not handled.
║  ║  ║ 
║  ║  ║ 0
║  ║  ║ 
║  ║  ║ Stack:
║  ║  ║ 
║  ║  ║ /workspace/io/examples/defects.ts:8:5
║  ║  ║ /workspace/io/examples/defects.ts:9:5
║  ║  ║ 
║  ║  ║ Execution:
║  ║  ║ 
║  ║  ║ /workspace/io/examples/defects.ts:8:16
║  ║  ║ /workspace/io/examples/defects.ts:8:5
║  ║  ║ /workspace/io/examples/defects.ts:12:17
║  ║  ║ 
║  ║  ▼
▼
```