### PR TITLE
make trackig fibers global

### DIFF
--- a/.changeset/rude-sheep-roll.md
+++ b/.changeset/rude-sheep-roll.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Track fibers globally

--- a/docs/modules/Fiber/Runtime/Flags.ts.md
+++ b/docs/modules/Fiber/Runtime/Flags.ts.md
@@ -14,8 +14,6 @@ Added in v1.0.0
 
 - [constructors](#constructors)
   - [CooperativeYielding](#cooperativeyielding)
-  - [CurrentFiber](#currentfiber)
-  - [FiberRoots](#fiberroots)
   - [Interruption](#interruption)
   - [None](#none)
   - [OpSupervision](#opsupervision)
@@ -33,23 +31,17 @@ Added in v1.0.0
   - [isEnabled](#isenabled)
 - [environment](#environment)
   - [disableCooperativeYielding](#disablecooperativeyielding)
-  - [disableCurrentFiber](#disablecurrentfiber)
-  - [disableFiberRoots](#disablefiberroots)
   - [disableInterruption](#disableinterruption)
   - [disableOpSupervision](#disableopsupervision)
   - [disableRuntimeMetrics](#disableruntimemetrics)
   - [disableWindDown](#disablewinddown)
   - [enableCooperativeYielding](#enablecooperativeyielding)
-  - [enableCurrentFiber](#enablecurrentfiber)
-  - [enableFiberRoots](#enablefiberroots)
   - [enableInterruption](#enableinterruption)
   - [enableOpSupervision](#enableopsupervision)
   - [enableRuntimeMetrics](#enableruntimemetrics)
   - [enableWindDown](#enablewinddown)
 - [getters](#getters)
   - [cooperativeYielding](#cooperativeyielding)
-  - [currentFiber](#currentfiber)
-  - [fiberRoots](#fiberroots)
   - [interruptible](#interruptible)
   - [interruption](#interruption)
   - [opSupervision](#opsupervision)
@@ -79,35 +71,6 @@ yield to another fiber.
 
 ```ts
 export declare const CooperativeYielding: RuntimeFlag
-```
-
-Added in v1.0.0
-
-## CurrentFiber
-
-The current fiber flag determines whether or not the Effect runtime system
-will store the current fiber whenever a fiber begins executing. Use of this
-flag will negatively impact performance, but is essential when tracking the
-current fiber is necessary.
-
-**Signature**
-
-```ts
-export declare const CurrentFiber: RuntimeFlag
-```
-
-Added in v1.0.0
-
-## FiberRoots
-
-The fiber roots flag determines whether or not the Effect runtime system will
-keep track of all fiber roots. Use of this flag will negatively impact
-performance, but is required for the fiber dumps functionality.
-
-**Signature**
-
-```ts
-export declare const FiberRoots: RuntimeFlag
 ```
 
 Added in v1.0.0
@@ -282,26 +245,6 @@ export declare const disableCooperativeYielding: () => Layer.Layer<never, never,
 
 Added in v1.0.0
 
-## disableCurrentFiber
-
-**Signature**
-
-```ts
-export declare const disableCurrentFiber: () => Layer.Layer<never, never, never>
-```
-
-Added in v1.0.0
-
-## disableFiberRoots
-
-**Signature**
-
-```ts
-export declare const disableFiberRoots: () => Layer.Layer<never, never, never>
-```
-
-Added in v1.0.0
-
 ## disableInterruption
 
 **Signature**
@@ -348,26 +291,6 @@ Added in v1.0.0
 
 ```ts
 export declare const enableCooperativeYielding: () => Layer.Layer<never, never, never>
-```
-
-Added in v1.0.0
-
-## enableCurrentFiber
-
-**Signature**
-
-```ts
-export declare const enableCurrentFiber: () => Layer.Layer<never, never, never>
-```
-
-Added in v1.0.0
-
-## enableFiberRoots
-
-**Signature**
-
-```ts
-export declare const enableFiberRoots: () => Layer.Layer<never, never, never>
 ```
 
 Added in v1.0.0
@@ -423,32 +346,6 @@ otherwise.
 
 ```ts
 export declare const cooperativeYielding: (self: RuntimeFlags) => boolean
-```
-
-Added in v1.0.0
-
-## currentFiber
-
-Returns `true` if the `CurrentFiber` `RuntimeFlag` is enabled, `false`
-otherwise.
-
-**Signature**
-
-```ts
-export declare const currentFiber: (self: RuntimeFlags) => boolean
-```
-
-Added in v1.0.0
-
-## fiberRoots
-
-Returns `true` if the `FiberRoots` `RuntimeFlag` is enabled, `false`
-otherwise.
-
-**Signature**
-
-```ts
-export declare const fiberRoots: (self: RuntimeFlags) => boolean
 ```
 
 Added in v1.0.0

--- a/src/Fiber/Runtime/Flags.ts
+++ b/src/Fiber/Runtime/Flags.ts
@@ -49,17 +49,6 @@ export const None: RuntimeFlag = internal.None
 export const Interruption: RuntimeFlag = internal.Interruption
 
 /**
- * The current fiber flag determines whether or not the Effect runtime system
- * will store the current fiber whenever a fiber begins executing. Use of this
- * flag will negatively impact performance, but is essential when tracking the
- * current fiber is necessary.
- *
- * @since 1.0.0
- * @category constructors
- */
-export const CurrentFiber: RuntimeFlag = internal.CurrentFiber
-
-/**
  * The op supervision flag determines whether or not the Effect runtime system
  * will supervise all operations of the Effect runtime. Use of this flag will
  * negatively impact performance, but is required for some operations, such as
@@ -81,16 +70,6 @@ export const OpSupervision: RuntimeFlag = internal.OpSupervision
  * @category constructors
  */
 export const RuntimeMetrics: RuntimeFlag = internal.RuntimeMetrics
-
-/**
- * The fiber roots flag determines whether or not the Effect runtime system will
- * keep track of all fiber roots. Use of this flag will negatively impact
- * performance, but is required for the fiber dumps functionality.
- *
- * @since 1.0.0
- * @category constructors
- */
-export const FiberRoots: RuntimeFlag = internal.FiberRoots
 
 /**
  * The wind down flag determines whether the Effect runtime system will execute
@@ -120,15 +99,6 @@ export const CooperativeYielding: RuntimeFlag = internal.CooperativeYielding
  * @category getters
  */
 export const cooperativeYielding: (self: RuntimeFlags) => boolean = internal.cooperativeYielding
-
-/**
- * Returns `true` if the `CurrentFiber` `RuntimeFlag` is enabled, `false`
- * otherwise.
- *
- * @since 1.0.0
- * @category getters
- */
-export const currentFiber: (self: RuntimeFlags) => boolean = internal.currentFiber
 
 /**
  * Creates a `RuntimeFlagsPatch` which describes the difference between `self`
@@ -168,18 +138,6 @@ export const disableAll: (flags: RuntimeFlags) => (self: RuntimeFlags) => Runtim
  * @category environment
  */
 export const disableCooperativeYielding: () => Layer.Layer<never, never, never> = circular.disableCooperativeYielding
-
-/**
- * @since 1.0.0
- * @category environment
- */
-export const disableCurrentFiber: () => Layer.Layer<never, never, never> = circular.disableCurrentFiber
-
-/**
- * @since 1.0.0
- * @category environment
- */
-export const disableFiberRoots: () => Layer.Layer<never, never, never> = circular.disableFiberRoots
 
 /**
  * @since 1.0.0
@@ -231,18 +189,6 @@ export const enableCooperativeYielding: () => Layer.Layer<never, never, never> =
  * @since 1.0.0
  * @category environment
  */
-export const enableCurrentFiber: () => Layer.Layer<never, never, never> = circular.enableCurrentFiber
-
-/**
- * @since 1.0.0
- * @category environment
- */
-export const enableFiberRoots: () => Layer.Layer<never, never, never> = circular.enableFiberRoots
-
-/**
- * @since 1.0.0
- * @category environment
- */
 export const enableInterruption: () => Layer.Layer<never, never, never> = circular.enableInterruption
 
 /**
@@ -262,15 +208,6 @@ export const enableRuntimeMetrics: () => Layer.Layer<never, never, never> = circ
  * @category environment
  */
 export const enableWindDown: () => Layer.Layer<never, never, never> = circular.enableWindDown
-
-/**
- * Returns `true` if the `FiberRoots` `RuntimeFlag` is enabled, `false`
- * otherwise.
- *
- * @since 1.0.0
- * @category getters
- */
-export const fiberRoots: (self: RuntimeFlags) => boolean = internal.fiberRoots
 
 /**
  * Returns true only if the `Interruption` flag is **enabled** and the

--- a/src/internal/fiber.ts
+++ b/src/internal/fiber.ts
@@ -422,7 +422,7 @@ export const pretty = <E, A>(self: Fiber.RuntimeFiber<E, A>): Effect.Effect<neve
 /** @internal */
 export const roots = (): Effect.Effect<never, never, Chunk.Chunk<Fiber.RuntimeFiber<any, any>>> => {
   const trace = getCallTrace()
-  return core.sync(() => Chunk.fromIterable(fiberScope._roots)).traced(trace)
+  return core.sync(() => Chunk.fromIterable(fiberScope.globalScope.roots)).traced(trace)
 }
 
 /** @internal */

--- a/src/internal/fiberScope.ts
+++ b/src/internal/fiberScope.ts
@@ -30,12 +30,18 @@ export interface FiberScope {
 class Global implements FiberScope {
   readonly [FiberScopeTypeId]: FiberScopeTypeId = FiberScopeTypeId
   readonly fiberId = FiberId.none
-  add(runtimeFlags: RuntimeFlags.RuntimeFlags, child: FiberRuntime.FiberRuntime<any, any>): void {
-    if (_runtimeFlags.isEnabled(_runtimeFlags.FiberRoots)(runtimeFlags)) {
-      _roots.add(child)
-      child.unsafeAddObserver(() => {
-        _roots.delete(child)
-      })
+  readonly roots = new Set<FiberRuntime.FiberRuntime<any, any>>()
+  add(_runtimeFlags: RuntimeFlags.RuntimeFlags, child: FiberRuntime.FiberRuntime<any, any>): void {
+    this.roots.add(child)
+    child.unsafeAddObserver(() => {
+      this.roots.delete(child)
+    })
+  }
+  constructor() {
+    if (typeof globalThis["@effect/io/FiberScope/Global"] === "undefined") {
+      globalThis["@effect/io/FiberScope/Global"] = this
+    } else {
+      throw new Error("Bug: @effect/io/FiberScope/Global initialized twice")
     }
   }
 }
@@ -65,7 +71,4 @@ export const unsafeMake = (fiber: FiberRuntime.FiberRuntime<any, any>): FiberSco
 }
 
 /** @internal */
-export const globalScope: FiberScope = new Global()
-
-/** @internal */
-export const _roots = new Set<FiberRuntime.FiberRuntime<any, any>>()
+export const globalScope = new Global()

--- a/src/internal/layer/circular.ts
+++ b/src/internal/layer/circular.ts
@@ -72,28 +72,10 @@ export const enableCooperativeYielding = (): Layer.Layer<never, never, never> =>
 }
 
 /** @internal */
-export const enableCurrentFiber = (): Layer.Layer<never, never, never> => {
-  return layer.scopedDiscard(
-    pipe(
-      fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.enable(runtimeFlags.CurrentFiber))
-    )
-  )
-}
-
-/** @internal */
 export const enableInterruption = (): Layer.Layer<never, never, never> => {
   return layer.scopedDiscard(
     pipe(
       fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.enable(runtimeFlags.Interruption))
-    )
-  )
-}
-
-/** @internal */
-export const enableFiberRoots = (): Layer.Layer<never, never, never> => {
-  return layer.scopedDiscard(
-    pipe(
-      fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.enable(runtimeFlags.FiberRoots))
     )
   )
 }
@@ -135,28 +117,10 @@ export const disableCooperativeYielding = (): Layer.Layer<never, never, never> =
 }
 
 /** @internal */
-export const disableCurrentFiber = (): Layer.Layer<never, never, never> => {
-  return layer.scopedDiscard(
-    pipe(
-      fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.disable(runtimeFlags.CurrentFiber))
-    )
-  )
-}
-
-/** @internal */
 export const disableInterruption = (): Layer.Layer<never, never, never> => {
   return layer.scopedDiscard(
     pipe(
       fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.disable(runtimeFlags.Interruption))
-    )
-  )
-}
-
-/** @internal */
-export const disableFiberRoots = (): Layer.Layer<never, never, never> => {
-  return layer.scopedDiscard(
-    pipe(
-      fiberRuntime.withRuntimeFlagsScoped(runtimeFlagsPatch.disable(runtimeFlags.FiberRoots))
     )
   )
 }

--- a/src/internal/runtime.ts
+++ b/src/internal/runtime.ts
@@ -230,7 +230,6 @@ export const runtime = <R>(): Effect.Effect<R, never, Runtime.Runtime<R>> => {
 
 /** @internal */
 export const defaultRuntimeFlags: RuntimeFlags.RuntimeFlags = runtimeFlags.make(
-  runtimeFlags.FiberRoots,
   runtimeFlags.Interruption,
   runtimeFlags.CooperativeYielding
 )

--- a/src/internal/runtimeFlags.ts
+++ b/src/internal/runtimeFlags.ts
@@ -10,31 +10,23 @@ export const None: RuntimeFlags.RuntimeFlag = 0 as RuntimeFlags.RuntimeFlag
 export const Interruption: RuntimeFlags.RuntimeFlag = 1 << 0 as RuntimeFlags.RuntimeFlag
 
 /** @internal */
-export const CurrentFiber: RuntimeFlags.RuntimeFlag = 1 << 1 as RuntimeFlags.RuntimeFlag
+export const OpSupervision: RuntimeFlags.RuntimeFlag = 1 << 1 as RuntimeFlags.RuntimeFlag
 
 /** @internal */
-export const OpSupervision: RuntimeFlags.RuntimeFlag = 1 << 2 as RuntimeFlags.RuntimeFlag
+export const RuntimeMetrics: RuntimeFlags.RuntimeFlag = 1 << 2 as RuntimeFlags.RuntimeFlag
 
 /** @internal */
-export const RuntimeMetrics: RuntimeFlags.RuntimeFlag = 1 << 3 as RuntimeFlags.RuntimeFlag
+export const WindDown: RuntimeFlags.RuntimeFlag = 1 << 4 as RuntimeFlags.RuntimeFlag
 
 /** @internal */
-export const FiberRoots: RuntimeFlags.RuntimeFlag = 1 << 4 as RuntimeFlags.RuntimeFlag
-
-/** @internal */
-export const WindDown: RuntimeFlags.RuntimeFlag = 1 << 5 as RuntimeFlags.RuntimeFlag
-
-/** @internal */
-export const CooperativeYielding: RuntimeFlags.RuntimeFlag = 1 << 6 as RuntimeFlags.RuntimeFlag
+export const CooperativeYielding: RuntimeFlags.RuntimeFlag = 1 << 5 as RuntimeFlags.RuntimeFlag
 
 /** @internal */
 export const allFlags: ReadonlyArray<RuntimeFlags.RuntimeFlag> = [
   None,
   Interruption,
-  CurrentFiber,
   OpSupervision,
   RuntimeMetrics,
-  FiberRoots,
   WindDown,
   CooperativeYielding
 ]
@@ -62,16 +54,6 @@ export const enable = (flag: RuntimeFlags.RuntimeFlag) => {
 /** @internal */
 export const enableAll = (flags: RuntimeFlags.RuntimeFlags) => {
   return (self: RuntimeFlags.RuntimeFlags): RuntimeFlags.RuntimeFlags => (self | flags) as RuntimeFlags.RuntimeFlags
-}
-
-/** @internal */
-export const currentFiber = (self: RuntimeFlags.RuntimeFlags): boolean => {
-  return isEnabled(CurrentFiber)(self)
-}
-
-/** @internal */
-export const fiberRoots = (self: RuntimeFlags.RuntimeFlags): boolean => {
-  return isEnabled(FiberRoots)(self)
 }
 
 /** @internal */

--- a/test/RuntimeFlags.ts
+++ b/test/RuntimeFlags.ts
@@ -7,10 +7,8 @@ import { assert, describe, it } from "vitest"
 const arbRuntimeFlag = fc.constantFrom(
   RuntimeFlags.None,
   RuntimeFlags.Interruption,
-  RuntimeFlags.CurrentFiber,
   RuntimeFlags.OpSupervision,
   RuntimeFlags.RuntimeMetrics,
-  RuntimeFlags.FiberRoots,
   RuntimeFlags.WindDown,
   RuntimeFlags.CooperativeYielding
 )
@@ -22,21 +20,19 @@ const arbRuntimeFlags = fc.uniqueArray(arbRuntimeFlag).map(
 describe.concurrent("RuntimeFlags", () => {
   it("isDisabled & isEnabled", () => {
     const flags = RuntimeFlags.make(
-      RuntimeFlags.CurrentFiber,
+      RuntimeFlags.RuntimeMetrics,
       RuntimeFlags.Interruption
     )
-    assert.isTrue(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.CurrentFiber)))
+    assert.isTrue(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.RuntimeMetrics)))
     assert.isTrue(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.Interruption)))
     assert.isFalse(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.CooperativeYielding)))
-    assert.isFalse(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.FiberRoots)))
     assert.isFalse(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.OpSupervision)))
-    assert.isFalse(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.RuntimeMetrics)))
     assert.isFalse(pipe(flags, RuntimeFlags.isEnabled(RuntimeFlags.WindDown)))
   })
 
   it("enabled patching", () => {
     const patch = pipe(
-      RuntimeFlagsPatch.enable(RuntimeFlags.CurrentFiber),
+      RuntimeFlagsPatch.enable(RuntimeFlags.RuntimeMetrics),
       RuntimeFlagsPatch.andThen(RuntimeFlagsPatch.enable(RuntimeFlags.OpSupervision))
     )
     const result = pipe(
@@ -44,7 +40,7 @@ describe.concurrent("RuntimeFlags", () => {
       RuntimeFlags.patch(patch)
     )
     const expected = RuntimeFlags.make(
-      RuntimeFlags.CurrentFiber,
+      RuntimeFlags.RuntimeMetrics,
       RuntimeFlags.OpSupervision
     )
     assert.strictEqual(result, expected)
@@ -52,15 +48,15 @@ describe.concurrent("RuntimeFlags", () => {
 
   it("inverse patching", () => {
     const flags = RuntimeFlags.make(
-      RuntimeFlags.CurrentFiber,
+      RuntimeFlags.RuntimeMetrics,
       RuntimeFlags.OpSupervision
     )
     const patch1 = pipe(
-      RuntimeFlagsPatch.enable(RuntimeFlags.CurrentFiber),
+      RuntimeFlagsPatch.enable(RuntimeFlags.RuntimeMetrics),
       RuntimeFlagsPatch.inverse
     )
     const patch2 = pipe(
-      RuntimeFlagsPatch.enable(RuntimeFlags.CurrentFiber),
+      RuntimeFlagsPatch.enable(RuntimeFlags.RuntimeMetrics),
       RuntimeFlagsPatch.andThen(RuntimeFlagsPatch.enable(RuntimeFlags.OpSupervision)),
       RuntimeFlagsPatch.inverse
     )
@@ -75,8 +71,8 @@ describe.concurrent("RuntimeFlags", () => {
   })
 
   it("diff", () => {
-    const flags1 = RuntimeFlags.make(RuntimeFlags.CurrentFiber)
-    const flags2 = RuntimeFlags.make(RuntimeFlags.CurrentFiber, RuntimeFlags.OpSupervision)
+    const flags1 = RuntimeFlags.make(RuntimeFlags.RuntimeMetrics)
+    const flags2 = RuntimeFlags.make(RuntimeFlags.RuntimeMetrics, RuntimeFlags.OpSupervision)
     assert.strictEqual(
       pipe(flags1, RuntimeFlags.diff(flags2)),
       RuntimeFlagsPatch.enable(RuntimeFlags.OpSupervision)


### PR DESCRIPTION
Tracking facilities are implemented in ZIO in a way that it is easy for jvm debuggers to get information, namely modules are required. In JS debuggers can't really load modules reliably to inspect properties so roots should be tracked in a shared global object.