### PR TITLE
Improve stringlogger logfmt compatibility

### DIFF
--- a/.changeset/cool-cycles-cheer.md
+++ b/.changeset/cool-cycles-cheer.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Improve stringlogger logfmt compatibility

--- a/src/internal/logSpan.ts
+++ b/src/internal/logSpan.ts
@@ -9,7 +9,7 @@ export const make = (label: string, startTime: number): LogSpan.LogSpan => ({
 /** @internal */
 export const render = (now: number) => {
   return (self: LogSpan.LogSpan): string => {
-    const label = self.label.indexOf(" ") < 0 ? self.label : `"${self.label}"`
+    const label = self.label.replace(/[ ="]/g, "_")
     return `${label}=${now - self.startTime}ms`
   }
 }

--- a/src/internal/logger.ts
+++ b/src/internal/logger.ts
@@ -56,15 +56,17 @@ export const stringLogger: Logger.Logger<string, string> = {
       `fiber=${_fiberId.threadName(fiberId)}`
     ]
 
+    let output = outputArray.join(" ")
+
     if (message.length > 0) {
-      outputArray.push(`message="${message}"`)
+      output = output + " message="
+      output = appendQuoted(message, output)
     }
 
     if (cause != null && cause != Cause.empty) {
-      outputArray.push(`cause="${runtime.unsafeRunSync(Pretty.prettySafe(cause, Pretty.defaultRenderer))}"`)
+      output = output + " cause="
+      output = appendQuoted(runtime.unsafeRunSync(Pretty.prettySafe(cause, Pretty.defaultRenderer)), output)
     }
-
-    let output = outputArray.join(" ")
 
     if (Chunk.isNonEmpty(spans)) {
       output = output + " "
@@ -90,7 +92,7 @@ export const stringLogger: Logger.Logger<string, string> = {
         } else {
           output = output + " "
         }
-        output = appendQuoted(key, output)
+        output = output + key.replace(/[ ="]/g, "_")
         output = output + "="
         output = appendQuoted(value, output)
       }
@@ -102,11 +104,7 @@ export const stringLogger: Logger.Logger<string, string> = {
 
 /** @internal */
 const appendQuoted = (label: string, output: string): string => {
-  if (label.indexOf(" ") < 0) {
-    return output + label
-  } else {
-    return output + `"${label}"`
-  }
+  return output + JSON.stringify(label)
 }
 
 /** @internal */

--- a/test/Logger.ts
+++ b/test/Logger.ts
@@ -1,0 +1,42 @@
+import * as Cause from "@effect/io/Cause"
+import * as FiberId from "@effect/io/Fiber/Id"
+import * as FiberRefs from "@effect/io/FiberRefs"
+import { logLevelInfo } from "@effect/io/internal/core"
+import * as LogSpan from "@effect/io/Logger/Span"
+import * as Runtime from "@effect/io/Runtime"
+
+import * as Logger from "@effect/io/Logger"
+import * as Chunk from "@fp-ts/data/Chunk"
+
+import { vi } from "vitest"
+
+describe("stringLogger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("keys with special chars", () => {
+    const date = new Date()
+    vi.setSystemTime(date)
+    const spans = Chunk.make(LogSpan.make("imma span", date.getTime()))
+    const annotations = new Map<string, string>([["I am bad key name", JSON.stringify({ coolValue: "cool value" })]])
+
+    const result = Logger.stringLogger.log(
+      FiberId.none,
+      logLevelInfo,
+      "My message",
+      Cause.empty,
+      FiberRefs.unsafeMake(new Map()),
+      spans,
+      annotations,
+      Runtime.defaultRuntime
+    )
+
+    expect(result).toEqual(
+      `timestamp=${date.toJSON()} level=INFO fiber= message="My message" imma_span=0ms I_am_bad_key_name="{\\"coolValue\\":\\"cool value\\"}"`
+    )
+  })
+})

--- a/test/Logger.ts
+++ b/test/Logger.ts
@@ -21,7 +21,7 @@ describe("stringLogger", () => {
   test("keys with special chars", () => {
     const date = new Date()
     vi.setSystemTime(date)
-    const spans = Chunk.make(LogSpan.make("imma span=\"", date.getTime()))
+    const spans = Chunk.make(LogSpan.make("imma span=\"", date.getTime() - 7))
     const annotations = new Map<string, string>([["I am bad key name", JSON.stringify({ coolValue: "cool value" })]])
 
     const result = Logger.stringLogger.log(
@@ -36,7 +36,7 @@ describe("stringLogger", () => {
     )
 
     expect(result).toEqual(
-      `timestamp=${date.toJSON()} level=INFO fiber= message="My message" imma_span__=0ms I_am_bad_key_name="{\\"coolValue\\":\\"cool value\\"}"`
+      `timestamp=${date.toJSON()} level=INFO fiber= message="My message" imma_span__=7ms I_am_bad_key_name="{\\"coolValue\\":\\"cool value\\"}"`
     )
   })
 })

--- a/test/Logger.ts
+++ b/test/Logger.ts
@@ -21,7 +21,7 @@ describe("stringLogger", () => {
   test("keys with special chars", () => {
     const date = new Date()
     vi.setSystemTime(date)
-    const spans = Chunk.make(LogSpan.make("imma span", date.getTime()))
+    const spans = Chunk.make(LogSpan.make("imma span=\"", date.getTime()))
     const annotations = new Map<string, string>([["I am bad key name", JSON.stringify({ coolValue: "cool value" })]])
 
     const result = Logger.stringLogger.log(
@@ -36,7 +36,7 @@ describe("stringLogger", () => {
     )
 
     expect(result).toEqual(
-      `timestamp=${date.toJSON()} level=INFO fiber= message="My message" imma_span=0ms I_am_bad_key_name="{\\"coolValue\\":\\"cool value\\"}"`
+      `timestamp=${date.toJSON()} level=INFO fiber= message="My message" imma_span__=0ms I_am_bad_key_name="{\\"coolValue\\":\\"cool value\\"}"`
     )
   })
 })


### PR DESCRIPTION
I found a better heuristic here https://github.com/csquared/node-logfmt/blob/master/lib/stringify.js
but newlines also need escaping according to https://github.com/csquared/node-logfmt/issues/39

Instead I found that using `JSON.stringify` on the strings, seems to provide exactly what we need.

- addresses problems with space, double quote and equals inside key names; they aren't allowed.
- addresses problems with various escaping that has to occur within values, beyond just double quoting when spaces found.

we may now add double quotes when we don't need it, but at least we never not apply them when we do need them..