### PR TITLE
fix: verify process is defined

### DIFF
--- a/src/internal_effect_untraced/debug.ts
+++ b/src/internal_effect_untraced/debug.ts
@@ -35,16 +35,18 @@ export const restoreOff: Restore = (body): any =>
     }
   }
 
+const hasProcessEnv = typeof process !== "undefined" && process.env
+
 /** @internal */
 export const runtimeDebug: Debug = {
   minumumLogLevel:
-    process && process.env && process.env["EFFECT_LOG_LEVEL"] && levels.includes(process.env["EFFECT_LOG_LEVEL"]) ?
+    hasProcessEnv && process.env["EFFECT_LOG_LEVEL"] && levels.includes(process.env["EFFECT_LOG_LEVEL"]) ?
       process.env["EFFECT_LOG_LEVEL"] as Debug["minumumLogLevel"] :
       "Info",
-  traceStackLimit: process && process.env && process.env["EFFECT_TRACING_STACK_LIMIT"] ?
+  traceStackLimit: hasProcessEnv && process.env["EFFECT_TRACING_STACK_LIMIT"] ?
     Number.parseInt(process.env["EFFECT_TRACING_STACK_LIMIT"]) :
     5,
-  tracingEnabled: process && process.env && process.env["EFFECT_TRACING_ENABLED"] &&
+  tracingEnabled: hasProcessEnv && process.env["EFFECT_TRACING_ENABLED"] &&
       process.env["EFFECT_TRACING_ENABLED"] === "false" ?
     false :
     true,


### PR DESCRIPTION
I was updating my libraries to the latest version of Effect when I encountered this bug when building for a browser where `process` is always undefined. I manually edited it in my node modules to test it working but figured I'd try to contribute it back. 

If there are any tests I should add or update, let me know.

<img width="936" alt="Screen Shot 2023-01-27 at 12 22 52 AM" src="https://user-images.githubusercontent.com/6282473/215015747-82a017a2-f5ff-485c-8a00-b9148802ec30.png">

