### PR TITLE
feat(effect): add refineTagOrDie* operators

### DIFF
--- a/.changeset/real-items-help.md
+++ b/.changeset/real-items-help.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+feat(effect): add refineTagOrDie\* operators

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -3219,6 +3219,42 @@ export const refineOrDieWith: {
 } = effect.refineOrDieWith
 
 /**
+ * Keeps only the error matching the specified tag, and terminates the fiber
+ * with the rest
+ *
+ * @since 1.0.0
+ * @category mutations
+ */
+export const refineTagOrDie: {
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    k: K,
+  ): (self: Effect<R, E, A>,)  => Effect<R, Extract<E, { _tag: K }>, A>,
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    self: Effect<R, E, A>,
+    k: K,
+  ): Effect<R, Extract<E, { _tag: K }>, A>
+} = effect.refineTagOrDie
+
+/**
+ * Keeps only the error matching the specified tag, and terminates the fiber
+ * with the rest, using the specified function to convert the `E` into a defect.
+ *
+ * @since 1.0.0
+ * @category mutations
+ */
+export const refineTagOrDieWith: {
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    k: K,
+    f: (e: E) => unknown
+  ): (self: Effect<R, E, A>)  => Effect<R, Extract<E, { _tag: K }>, A>,
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    self: Effect<R, E, A>,
+    k: K,
+    f: (e: E) => unknown
+  ): Effect<R, Extract<E, { _tag: K }>, A>
+} = effect.refineTagOrDieWith
+
+/**
  * Fail with the returned value if the `PartialFunction` matches, otherwise
  * continue with our held value.
  *

--- a/src/internal_effect_untraced/effect.ts
+++ b/src/internal_effect_untraced/effect.ts
@@ -2089,6 +2089,37 @@ export const refineOrDieWith = Debug.dualWithTrace<
     }).traced(trace))
 
 /* @internal */
+export const refineTagOrDie = Debug.dualWithTrace<
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    k: K
+  ) => (self: Effect.Effect<R, E, A>) => Effect.Effect<R, Extract<E, { _tag: K }>, A>,
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    self: Effect.Effect<R, E, A>,
+    k: K
+  ) => Effect.Effect<R, Extract<E, { _tag: K }>, A>
+>(2, (trace) => (self, k) => refineTagOrDieWith(self, k, identity).traced(trace))
+
+/* @internal */
+export const refineTagOrDieWith = Debug.dualWithTrace<
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    k: K,
+    f: (e: E) => unknown
+  ) => (self: Effect.Effect<R, E, A>) => Effect.Effect<R, Extract<E, { _tag: K }>, A>,
+  <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
+    self: Effect.Effect<R, E, A>,
+    k: K,
+    f: (e: E) => unknown
+  ) => Effect.Effect<R, Extract<E, { _tag: K }>, A>
+>(3, (trace, restore) =>
+  (self, k, f) =>
+    core.catchAll(self, (e) => {
+      if ("_tag" in e && e["_tag"] === k) {
+        return core.fail(e as any)
+      }
+      return core.die(restore(f)(e))
+    }).traced(trace))
+
+/* @internal */
 export const reject = Debug.dualWithTrace<
   <A, E1>(pf: (a: A) => Option.Option<E1>) => <R, E>(self: Effect.Effect<R, E, A>) => Effect.Effect<R, E | E1, A>,
   <R, E, A, E1>(self: Effect.Effect<R, E, A>, pf: (a: A) => Option.Option<E1>) => Effect.Effect<R, E | E1, A>

--- a/test/Effect/error-handling.ts
+++ b/test/Effect/error-handling.ts
@@ -621,6 +621,36 @@ describe.concurrent("Effect", () => {
       const result = yield* $(Effect.exit(deepErrorEffect(100)))
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(ExampleError))
     }))
+  it.effect("refineTagOrDie - leaves the tagged error as failure", () =>
+    Effect.gen(function*($) {
+      interface ErrorA {
+        readonly _tag: "ErrorA"
+      }
+      interface ErrorB {
+        readonly _tag: "ErrorB"
+      }
+      const effect: Effect.Effect<never, ErrorA | ErrorB, never> = Effect.fail({ _tag: "ErrorA" })
+      const result = yield* $(pipe(
+        Effect.refineTagOrDie(effect, "ErrorA"),
+        Effect.exit
+      ))
+      assert.deepStrictEqual(Exit.unannotate(result), Exit.fail({ _tag: "ErrorA" }))
+    }))
+  it.effect("refineTagOrDie - converts the rest to defects", () =>
+    Effect.gen(function*($) {
+      interface ErrorA {
+        readonly _tag: "ErrorA"
+      }
+      interface ErrorB {
+        readonly _tag: "ErrorB"
+      }
+      const effect: Effect.Effect<never, ErrorA | ErrorB, never> = Effect.fail({ _tag: "ErrorA" })
+      const result = yield* $(pipe(
+        Effect.refineTagOrDie(effect, "ErrorB"),
+        Effect.exit
+      ))
+      assert.deepStrictEqual(Exit.unannotate(result), Exit.die({ _tag: "ErrorA" }))
+    }))
   it.effect("unrefine - converts some fiber failures into errors", () =>
     Effect.gen(function*($) {
       const message = "division by zero"


### PR DESCRIPTION
ZIO has refineToOrDie to narrow the failure's channel type.

Since Effect has catchTag to perform narrowing on catch semantics, it only seems fitting to have a refineTagOrDie that performs similar narrowing logic automatically for refining semantics.

⚠️ first contribution, **review with extra attention** because I may have done stupid things! Most of the implementation is cargo-culted from catchTag and refineOrDie (especially trace / resolve stuff which I have no idea how it works).