### PR TITLE
refineTagOrDieWith: narrow callback argument type

### DIFF
--- a/.changeset/metal-mirrors-change.md
+++ b/.changeset/metal-mirrors-change.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+refineTagOrDieWith: narrow callback argument type

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -3245,12 +3245,12 @@ export const refineTagOrDie: {
 export const refineTagOrDieWith: {
   <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
     k: K,
-    f: (e: E) => unknown
+    f: (e: Exclude<E, { _tag: K }>) => unknown
   ): (self: Effect<R, E, A>)  => Effect<R, Extract<E, { _tag: K }>, A>,
   <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
     self: Effect<R, E, A>,
     k: K,
-    f: (e: E) => unknown
+    f: (e: Exclude<E, { _tag: K }>) => unknown
   ): Effect<R, Extract<E, { _tag: K }>, A>
 } = effect.refineTagOrDieWith
 

--- a/src/internal_effect_untraced/effect.ts
+++ b/src/internal_effect_untraced/effect.ts
@@ -2103,12 +2103,12 @@ export const refineTagOrDie = Debug.dualWithTrace<
 export const refineTagOrDieWith = Debug.dualWithTrace<
   <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
     k: K,
-    f: (e: E) => unknown
+    f: (e: Exclude<E, { _tag: K }>) => unknown
   ) => (self: Effect.Effect<R, E, A>) => Effect.Effect<R, Extract<E, { _tag: K }>, A>,
   <R, E extends { _tag: string }, A, K extends E["_tag"] & string>(
     self: Effect.Effect<R, E, A>,
     k: K,
-    f: (e: E) => unknown
+    f: (e: Exclude<E, { _tag: K }>) => unknown
   ) => Effect.Effect<R, Extract<E, { _tag: K }>, A>
 >(3, (trace, restore) =>
   (self, k, f) =>
@@ -2116,7 +2116,7 @@ export const refineTagOrDieWith = Debug.dualWithTrace<
       if ("_tag" in e && e["_tag"] === k) {
         return core.fail(e as any)
       }
-      return core.die(restore(f)(e))
+      return core.die(restore(f)(e as any))
     }).traced(trace))
 
 /* @internal */

--- a/test/Effect/error-handling.ts
+++ b/test/Effect/error-handling.ts
@@ -651,6 +651,22 @@ describe.concurrent("Effect", () => {
       ))
       assert.deepStrictEqual(Exit.unannotate(result), Exit.die({ _tag: "ErrorA" }))
     }))
+  it.effect("refineTagOrDieWith - narrows callback argument type", () =>
+    Effect.gen(function*($) {
+      interface ErrorA {
+        readonly _tag: "ErrorA"
+        readonly a: "a"
+      }
+      interface ErrorB {
+        readonly _tag: "ErrorB"
+      }
+      const effect: Effect.Effect<never, ErrorA | ErrorB, never> = Effect.fail({ _tag: "ErrorA", a: "a" })
+      const result = yield* $(pipe(
+        Effect.refineTagOrDieWith(effect, "ErrorB", (e) => e.a),
+        Effect.exit
+      ))
+      assert.deepStrictEqual(Exit.unannotate(result), Exit.die("a"))
+    }))
   it.effect("unrefine - converts some fiber failures into errors", () =>
     Effect.gen(function*($) {
       const message = "division by zero"


### PR DESCRIPTION
While the original implementation in bb7c80d is not incorrect, the callback's argument type was left unnecessarily wide making user DX not optimal.