### PR TITLE
Improve error semantics

### DIFF
--- a/.changeset/short-pots-sip.md
+++ b/.changeset/short-pots-sip.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": minor
+---
+
+Improve error semantics


### PR DESCRIPTION
Changed behaviour of:
1) orElse variants to elect failures to defects in case a defect is present instead of silently losing the failure
2) catchAll variants to elect failures to defects in case a defect is present instead of silently losing the defect

We still recover with both 1 & 2 in case of multiple failures present, which seems to be an expected and wanted property given a test fails if I switch to elect failures to defects in case of multiple