### PR TITLE
Add absolveWith function

### DIFF
--- a/.changeset/clean-candles-know.md
+++ b/.changeset/clean-candles-know.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+add absolveWith combinator

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 .cache/
 .direnv/
+.idea/

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -189,6 +189,32 @@ export const addFinalizer: <R, X>(
 export const absolve: <R, E, A>(self: Effect<R, E, Either.Either<E, A>>) => Effect<R, E, A> = effect.absolve
 
 /**
+ * This function takes a mapping function f that maps over `Effect` value
+ * and returns `Either` and returns a new function that submerges the error
+ * case of an `Either` value into an `Effect` value.
+ * It is the inverse operation of `either`.
+ *
+ * If the `Either` value is a `Right` value, then the `Effect` value will
+ * succeed with the value contained in the `Right`. If the `Either` value
+ * is a `Left` value, then the `Effect` value will fail with the error
+ * contained in the `Left`.
+ *
+ * @param self - The `Effect` value that contains an `Either` value as its
+ * result.
+ *
+ * @returns A new `Effect` value that has the same context as the original
+ * `Effect` value, but has the error case of the `Either` value submerged
+ * into it.
+ *
+ * @since 1.0.0
+ * @category error handling
+ */
+export const absolveWith: {
+  <A, E2, A2>(f: (a: A) => Either.Either<E2, A2>): <R, E>(self: Effect<R, E, A>) => Effect<R, E | E2, A2>
+  <R, E, E2, A, A2>(self: Effect<R, E, A>, f: (a: A) => Either.Either<E2, A2>): Effect<R, E | E2, A2>
+} = effect.absolveWith
+
+/**
  * This function transforms an `Effect` value that may fail with a defect
  * into a new `Effect` value that may fail with an unknown error.
  *

--- a/src/internal_effect_untraced/effect.ts
+++ b/src/internal_effect_untraced/effect.ts
@@ -37,7 +37,19 @@ export { dieMessage, dieOnSync } from "@effect/io/internal_effect_untraced/clock
 /* @internal */
 export const absolve = Debug.methodWithTrace((trace) =>
   <R, E, A>(self: Effect.Effect<R, E, Either.Either<E, A>>): Effect.Effect<R, E, A> =>
-    core.flatMap(self, core.fromEither).traced(trace)
+    absolveWith(self, identity).traced(trace)
+)
+
+/* @internal */
+export const absolveWith = Debug.dualWithTrace<
+  <A, E2, A2>(
+    f: (a: A) => Either.Either<E2, A2>
+  ) => <R, E>(self: Effect.Effect<R, E, A>) => Effect.Effect<R, E | E2, A2>,
+  <R, E, E2, A, A2>(self: Effect.Effect<R, E, A>, f: (a: A) => Either.Either<E2, A2>) => Effect.Effect<R, E | E2, A2>
+>(
+  2,
+  (trace, restore) =>
+    (self, f) => pipe(self, core.flatMap((value) => pipe(value, restore(f), core.fromEither))).traced(trace)
 )
 
 /* @internal */

--- a/test/Effect/error-handling.ts
+++ b/test/Effect/error-handling.ts
@@ -60,6 +60,20 @@ describe.concurrent("Effect", () => {
       const result = yield* $(pipe(Effect.succeed(Either.right("test")), Effect.absolve))
       assert.strictEqual(result, "test")
     }))
+  it.effect("absolveWith right", () =>
+    Effect.gen(function*($) {
+      const result = yield* $(
+        pipe(Effect.succeed(Either.right("test")), Effect.absolveWith(() => Either.right("absolveRight")))
+      )
+      assert.strictEqual(result, "absolveRight")
+    }))
+  it.effect("absolveWith left", () =>
+    Effect.gen(function*($) {
+      const result = yield* $(
+        pipe(Effect.succeed("test"), Effect.absolveWith(() => Either.left("absolveLeft" as const)), Effect.exit)
+      )
+      assert.deepStrictEqual(Exit.unannotate(result), Exit.fail("absolveLeft"))
+    }))
   it.effect("absorbWith - on fail", () =>
     Effect.gen(function*($) {
       const result = yield* $(pipe(ExampleErrorFail, Effect.absorbWith(Option.some), Effect.exit))


### PR DESCRIPTION
It works like [`RTE.chainEitherKW`](https://gcanti.github.io/fp-ts/modules/ReaderTaskEither.ts.html#chaineitherkw) from fp-ts.

It's combinator for `pipe(Z.map(fn), Z.absolve)` -> `Z.absolveWith(fn)`