### PR TITLE
align FiberFailure stack with new Error().stack format.

### DIFF
--- a/.changeset/wild-donkeys-heal.md
+++ b/.changeset/wild-donkeys-heal.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": minor
+---
+
+Improve design of FiberFailure to be a normal Error

--- a/docs/modules/Runtime.ts.md
+++ b/docs/modules/Runtime.ts.md
@@ -26,10 +26,21 @@ Added in v1.0.0
   - [runSyncEither](#runsynceither)
   - [runSyncExit](#runsyncexit)
   - [runSyncExitOrFiber](#runsyncexitorfiber)
+- [exports](#exports)
+  - [FiberFailureCauseId (type alias)](#fiberfailurecauseid-type-alias)
+- [guards](#guards)
+  - [isFiberFailure](#isfiberfailure)
 - [models](#models)
   - [AsyncFiber (interface)](#asyncfiber-interface)
   - [Cancel (interface)](#cancel-interface)
+  - [FiberFailure (interface)](#fiberfailure-interface)
   - [Runtime (interface)](#runtime-interface)
+- [symbols](#symbols)
+  - [FiberFailureCauseId](#fiberfailurecauseid)
+  - [FiberFailureId](#fiberfailureid)
+  - [FiberFailureId (type alias)](#fiberfailureid-type-alias)
+  - [NodePrint](#nodeprint)
+  - [NodePrint (type alias)](#nodeprint-type-alias)
 
 ---
 
@@ -225,6 +236,30 @@ export declare const runSyncExitOrFiber: <R>(
 
 Added in v1.0.0
 
+# exports
+
+## FiberFailureCauseId (type alias)
+
+**Signature**
+
+```ts
+export type FiberFailureCauseId = typeof FiberFailureCauseId
+```
+
+Added in v1.0.0
+
+# guards
+
+## isFiberFailure
+
+**Signature**
+
+```ts
+export declare const isFiberFailure: (u: unknown) => u is FiberFailure
+```
+
+Added in v1.0.0
+
 # models
 
 ## AsyncFiber (interface)
@@ -252,6 +287,20 @@ export interface Cancel<E, A> {
 
 Added in v1.0.0
 
+## FiberFailure (interface)
+
+**Signature**
+
+```ts
+export interface FiberFailure extends Error {
+  readonly [FiberFailureId]: FiberFailureId
+  readonly [FiberFailureCauseId]: Cause<unknown>
+  readonly [NodePrint]: () => string
+}
+```
+
+Added in v1.0.0
+
 ## Runtime (interface)
 
 **Signature**
@@ -271,6 +320,58 @@ export interface Runtime<R> {
    */
   readonly fiberRefs: FiberRefs.FiberRefs
 }
+```
+
+Added in v1.0.0
+
+# symbols
+
+## FiberFailureCauseId
+
+**Signature**
+
+```ts
+export declare const FiberFailureCauseId: typeof FiberFailureCauseId
+```
+
+Added in v1.0.0
+
+## FiberFailureId
+
+**Signature**
+
+```ts
+export declare const FiberFailureId: typeof FiberFailureId
+```
+
+Added in v1.0.0
+
+## FiberFailureId (type alias)
+
+**Signature**
+
+```ts
+export type FiberFailureId = typeof FiberFailureId
+```
+
+Added in v1.0.0
+
+## NodePrint
+
+**Signature**
+
+```ts
+export declare const NodePrint: typeof NodePrint
+```
+
+Added in v1.0.0
+
+## NodePrint (type alias)
+
+**Signature**
+
+```ts
+export type NodePrint = typeof NodePrint
 ```
 
 Added in v1.0.0

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -3,6 +3,7 @@
  */
 import type * as Context from "@effect/data/Context"
 import type { Either } from "@effect/data/Either"
+import type { Cause } from "@effect/io/Cause"
 import type * as Effect from "@effect/io/Effect"
 import type * as Exit from "@effect/io/Exit"
 import type * as Fiber from "@effect/io/Fiber"
@@ -195,3 +196,54 @@ export const make: <R>(
   runtimeFlags: RuntimeFlags.RuntimeFlags,
   fiberRefs: FiberRefs.FiberRefs
 ) => Runtime<R> = internal.make
+
+/**
+ * @since 1.0.0
+ * @category symbols
+ */
+export const FiberFailureId = Symbol.for("@effect/io/Runtime/FiberFailure")
+/**
+ * @since 1.0.0
+ * @category symbols
+ */
+export type FiberFailureId = typeof FiberFailureId
+
+/**
+ * @since 1.0.0
+ * @category symbols
+ */
+export const FiberFailureCauseId: unique symbol = internal.FiberFailureCauseId
+
+/**
+ * @since 1.0.0
+ * @category exports
+ */
+export type FiberFailureCauseId = typeof FiberFailureCauseId
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface FiberFailure extends Error {
+  readonly [FiberFailureId]: FiberFailureId
+  readonly [FiberFailureCauseId]: Cause<unknown>
+  readonly [NodePrint]: () => string
+}
+
+/**
+ * @since 1.0.0
+ * @category symbols
+ */
+export const NodePrint: unique symbol = internal.NodePrint
+
+/**
+ * @since 1.0.0
+ * @category symbols
+ */
+export type NodePrint = typeof NodePrint
+
+/**
+ * @since 1.0.0
+ * @category guards
+ */
+export const isFiberFailure: (u: unknown) => u is FiberFailure = internal.isFiberFailure

--- a/src/internal_effect_untraced/runtime.ts
+++ b/src/internal_effect_untraced/runtime.ts
@@ -146,28 +146,44 @@ export class AsyncFiber<E, A> implements Runtime.AsyncFiber<E, A> {
   }
 }
 
-class FiberFailure extends Error {
-  readonly _tag = "FiberFailure"
-  readonly _id = Symbol.for("@effect/io/Runtime/FiberFailure")
-  constructor(readonly originalCause: Cause.Cause<unknown>) {
-    const limit = Error.stackTraceLimit
-    Error.stackTraceLimit = 0
-    super()
-    Error.stackTraceLimit = limit
-    const pretty = CausePretty.prettyErrors(this.originalCause)
-    if (pretty.length > 0) {
-      this.name = pretty[0].message.split(":")[0]
-      this.message = pretty[0].message.substring(this.name.length + 2)
-      this.stack = `${this.name}: ${this.message}\n${pretty[0].stack}`
-    }
-  }
-  toString() {
-    return CausePretty.pretty(this.originalCause)
-  }
-  [Symbol.for("nodejs.util.inspect.custom")]() {
-    return this.toString()
-  }
+/** @internal */
+export const FiberFailureId: Runtime.FiberFailureId = Symbol.for("@effect/io/Runtime/FiberFailure") as any
+/** @internal */
+export const FiberFailureCauseId: Runtime.FiberFailureCauseId = Symbol.for(
+  "@effect/io/Runtime/FiberFailure/Cause"
+) as any
+
+type Mutable<A> = {
+  -readonly [k in keyof A]: A[k]
 }
+/** @internal */
+export const NodePrint: Runtime.NodePrint = Symbol.for("nodejs.util.inspect.custom") as any
+
+const fiberFailure = (cause: Cause.Cause<unknown>): Runtime.FiberFailure => {
+  const limit = Error.stackTraceLimit
+  Error.stackTraceLimit = 0
+  const error = (new Error()) as Mutable<Runtime.FiberFailure>
+  Error.stackTraceLimit = limit
+  const pretty = CausePretty.prettyErrors(cause)
+  if (pretty.length > 0) {
+    error.name = pretty[0].message.split(":")[0]
+    error.message = pretty[0].message.substring(error.name.length + 2)
+    error.stack = `${error.name}: ${error.message}\n${pretty[0].stack}`
+  }
+  error[FiberFailureId] = FiberFailureId
+  error[FiberFailureCauseId] = cause
+  error.toString = () => {
+    return CausePretty.pretty(cause)
+  }
+  error[NodePrint] = () => {
+    return error.toString()
+  }
+  return error
+}
+
+/** @internal */
+export const isFiberFailure = (u: unknown): u is Runtime.FiberFailure =>
+  typeof u === "object" && u !== null && FiberFailureId in u
 
 /** @internal */
 export const unsafeRunSync = <R>(runtime: Runtime.Runtime<R>) =>
@@ -175,7 +191,7 @@ export const unsafeRunSync = <R>(runtime: Runtime.Runtime<R>) =>
     <E, A>(effect: Effect.Effect<R, E, A>): A => {
       const exit = unsafeRunSyncExit(runtime)(effect.traced(trace))
       if (exit._tag === OpCodes.OP_FAILURE) {
-        throw new FiberFailure(exit.i0)
+        throw fiberFailure(exit.i0)
       }
       return exit.i0
     }
@@ -197,7 +213,7 @@ export const unsafeRunPromise = <R>(runtime: Runtime.Runtime<R>) =>
             break
           }
           case OpCodes.OP_FAILURE: {
-            reject(new FiberFailure(exit.i0))
+            reject(fiberFailure(exit.i0))
             break
           }
         }

--- a/src/internal_effect_untraced/runtime.ts
+++ b/src/internal_effect_untraced/runtime.ts
@@ -158,7 +158,7 @@ class FiberFailure extends Error {
     if (pretty.length > 0) {
       this.name = pretty[0].message.split(":")[0]
       this.message = pretty[0].message.substring(this.name.length + 2)
-      this.stack = pretty[0].stack
+      this.stack = `${this.name}: ${this.message}\n${pretty[0].stack}`
     }
   }
   toString() {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,5 +6,7 @@
     "tsBuildInfoFile": "build/tsbuildinfo/esm.tsbuildinfo",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
aligns with: `new Error("imm a message").stack`:

```
'Error: imm a message\n' +
  '    at REPL19:1:11\n' +
  '    at Script.runInThisContext (node:vm:129:12)\n' +
  '    at REPLServer.defaultEval (node:repl:572:29)\n' +
  '    at bound (node:domain:433:15)\n' +
  '    at REPLServer.runBound [as eval] (node:domain:444:12)\n' +
  '    at REPLServer.onLine (node:repl:902:10)\n' +
  '    at REPLServer.emit (node:events:525:35)\n' +
  '    at REPLServer.emit (node:domain:489:12)\n' +
  '    at [_onLine] [as _onLine] (node:internal/readline/interface:422:12)\n' +
  '    at [_line] [as _line] (node:internal/readline/interface:893:18)'
  ```