### PR TITLE
Remove tracking of execution mode

### DIFF
--- a/.changeset/sharp-bats-whisper.md
+++ b/.changeset/sharp-bats-whisper.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Remove tracking of execution mode

--- a/docs/modules/Scheduler.ts.md
+++ b/docs/modules/Scheduler.ts.md
@@ -38,6 +38,8 @@ Added in v1.0.0
 
 ```ts
 export interface Scheduler {
+  scheduleTask(task: Task): void
+}
 ```
 
 Added in v1.0.0

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -15,17 +15,12 @@ export type Task = () => void
  * @category models
  */
 export interface Scheduler {
-  get executionMode(): "PreferSync" | "PreferAsync" | "Sync"
   scheduleTask(task: Task): void
 }
 
 class DefaultScheduler implements Scheduler {
   running = false
   tasks: Array<Task> = []
-
-  get executionMode(): "PreferSync" | "PreferAsync" | "Sync" {
-    return "PreferAsync"
-  }
 
   starveInternal(depth: number) {
     const toRun = this.tasks
@@ -97,16 +92,6 @@ export class SyncScheduler implements Scheduler {
     } else {
       this.tasks.push(task)
     }
-  }
-
-  /**
-   * @since 1.0.0
-   */
-  get executionMode(): "PreferSync" | "PreferAsync" | "Sync" {
-    if (this.deferred) {
-      return defaultScheduler.executionMode
-    }
-    return this.initialMode
   }
 
   /**


### PR DESCRIPTION
Forbidding async for all the fiber tree is too unintuitive when running in sync