### PR TITLE
Avoid logging final errors when using runPromise/runSync/runCallback, remove conditional orFiber

### DIFF
--- a/.changeset/flat-lions-accept.md
+++ b/.changeset/flat-lions-accept.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": minor
+---
+
+Avoid logging final errors when using runPromise/runSync/runCallback, remove conditional orFiber

--- a/docs/modules/Effect.ts.md
+++ b/docs/modules/Effect.ts.md
@@ -199,8 +199,6 @@ Added in v1.0.0
   - [runSync](#runsync)
   - [runSyncEither](#runsynceither)
   - [runSyncExit](#runsyncexit)
-  - [runSyncExitOrFiber](#runsyncexitorfiber)
-  - [runSyncFiber](#runsyncfiber)
 - [filtering](#filtering)
   - [filter](#filter)
   - [filterNot](#filternot)
@@ -3357,30 +3355,6 @@ Added in v1.0.0
 
 ```ts
 export declare const runSyncExit: <E, A>(effect: Effect<never, E, A>) => Exit.Exit<E, A>
-```
-
-Added in v1.0.0
-
-## runSyncExitOrFiber
-
-**Signature**
-
-```ts
-export declare const runSyncExitOrFiber: <E, A>(
-  effect: Effect<never, E, A>
-) => Either.Either<Fiber.Fiber<never, Exit.Exit<E, A>>, Exit.Exit<E, A>>
-```
-
-Added in v1.0.0
-
-## runSyncFiber
-
-**Signature**
-
-```ts
-export declare const runSyncFiber: <R>(
-  runtime: Runtime.Runtime<R>
-) => <E, A>(effect: Effect<R, E, A>) => Either.Either<Fiber.Fiber<E, A>, A>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Runtime.ts.md
+++ b/docs/modules/Runtime.ts.md
@@ -26,8 +26,6 @@ Added in v1.0.0
   - [runSync](#runsync)
   - [runSyncEither](#runsynceither)
   - [runSyncExit](#runsyncexit)
-  - [runSyncExitOrFiber](#runsyncexitorfiber)
-  - [runSyncOrFiber](#runsyncorfiber)
 - [exports](#exports)
   - [FiberFailureCauseId (type alias)](#fiberfailurecauseid-type-alias)
 - [guards](#guards)
@@ -227,40 +225,6 @@ program.
 
 ```ts
 export declare const runSyncExit: <R>(runtime: Runtime<R>) => <E, A>(effect: Effect.Effect<R, E, A>) => Exit.Exit<E, A>
-```
-
-Added in v1.0.0
-
-## runSyncExitOrFiber
-
-Executes the effect synchronously returning the exit or the fiber if async.
-
-This method is effectful and should only be invoked at the edges of your
-program.
-
-**Signature**
-
-```ts
-export declare const runSyncExitOrFiber: <R>(
-  runtime: Runtime<R>
-) => <E, A>(effect: Effect.Effect<R, E, A>) => Either<Fiber.Fiber<never, Exit.Exit<E, A>>, Exit.Exit<E, A>>
-```
-
-Added in v1.0.0
-
-## runSyncOrFiber
-
-Executes the effect synchronously returning the exit or the fiber if async.
-
-This method is effectful and should only be invoked at the edges of your
-program.
-
-**Signature**
-
-```ts
-export declare const runSyncOrFiber: <R>(
-  runtime: Runtime<R>
-) => <E, A>(effect: Effect.Effect<R, E, A>) => Either<Fiber.Fiber<E, A>, A>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Scheduler.ts.md
+++ b/docs/modules/Scheduler.ts.md
@@ -61,14 +61,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare class ControlledScheduler {
-  constructor(
-    /**
-     * @since 1.0.0
-     */
-    readonly currentMode: () => 'PreferSync' | 'PreferAsync' | 'Sync'
-  )
-}
+export declare class ControlledScheduler
 ```
 
 Added in v1.0.0
@@ -118,14 +111,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare class SyncScheduler {
-  constructor(
-    /**
-     * @since 1.0.0
-     */
-    readonly initialMode: 'PreferSync' | 'PreferAsync' | 'Sync'
-  )
-}
+export declare class SyncScheduler
 ```
 
 Added in v1.0.0

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -4756,22 +4756,6 @@ export const runSyncExit: <E, A>(effect: Effect<never, E, A>) => Exit.Exit<E, A>
  * @since 1.0.0
  * @category execution
  */
-export const runSyncExitOrFiber: <E, A>(
-  effect: Effect<never, E, A>
-) => Either.Either<Fiber.Fiber<never, Exit.Exit<E, A>>, Exit.Exit<E, A>> = _runtime.unsafeRunSyncExitOrFiberEffect
-
-/**
- * @since 1.0.0
- * @category execution
- */
-export const runSyncFiber: <R>(
-  runtime: Runtime.Runtime<R>
-) => <E, A>(effect: Effect<R, E, A>) => Either.Either<Fiber.Fiber<E, A>, A> = _runtime.unsafeRunSyncOrFiber
-
-/**
- * @since 1.0.0
- * @category execution
- */
 export const runSyncEither: <E, A>(effect: Effect<never, E, A>) => Either.Either<E, A> =
   _runtime.unsafeRunSyncEitherEffect
 

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -76,33 +76,6 @@ export const runSyncExit: <R>(runtime: Runtime<R>) => <E, A>(effect: Effect.Effe
   internal.unsafeRunSyncExit
 
 /**
- * Executes the effect synchronously returning the exit or the fiber if async.
- *
- * This method is effectful and should only be invoked at the edges of your
- * program.
- *
- * @since 1.0.0
- * @category execution
- */
-export const runSyncExitOrFiber: <R>(
-  runtime: Runtime<R>
-) => <E, A>(effect: Effect.Effect<R, E, A>) => Either<Fiber.Fiber<never, Exit.Exit<E, A>>, Exit.Exit<E, A>> =
-  internal.unsafeRunSyncExitOrFiber
-
-/**
- * Executes the effect synchronously returning the exit or the fiber if async.
- *
- * This method is effectful and should only be invoked at the edges of your
- * program.
- *
- * @since 1.0.0
- * @category execution
- */
-export const runSyncOrFiber: <R>(
-  runtime: Runtime<R>
-) => <E, A>(effect: Effect.Effect<R, E, A>) => Either<Fiber.Fiber<E, A>, A> = internal.unsafeRunSyncOrFiber
-
-/**
  * Executes the effect synchronously throwing in case of errors or async boundaries.
  *
  * This method is effectful and should only be invoked at the edges of your

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -76,13 +76,6 @@ export class SyncScheduler implements Scheduler {
    */
   deferred = false
 
-  constructor(
-    /**
-     * @since 1.0.0
-     */
-    readonly initialMode: "PreferSync" | "PreferAsync" | "Sync"
-  ) {}
-
   /**
    * @since 1.0.0
    */
@@ -124,13 +117,6 @@ export class ControlledScheduler implements Scheduler {
    */
   deferred = false
 
-  constructor(
-    /**
-     * @since 1.0.0
-     */
-    readonly currentMode: () => "PreferSync" | "PreferAsync" | "Sync"
-  ) {}
-
   /**
    * @since 1.0.0
    */
@@ -140,13 +126,6 @@ export class ControlledScheduler implements Scheduler {
     } else {
       this.tasks.push(task)
     }
-  }
-
-  /**
-   * @since 1.0.0
-   */
-  get executionMode(): "PreferSync" | "PreferAsync" | "Sync" {
-    return this.currentMode()
   }
 
   /**


### PR DESCRIPTION
While `orFiber` variants have use cases such use cases are so low level that most likely one would benefit from using runFork instead. While it is possible to maintain those variants it may be counter intuitive to get the fiber for `Exit<never, Exit<E, A>>` instead given the escape for logging that is now default in runX methods