### PR TITLE
Pipeable resume in do-notation

### DIFF
--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1977,12 +1977,274 @@ export interface EffectGen<R, E, A> {
   [Symbol.iterator](): Generator<EffectGen<R, E, A>, A>
 }
 
+type ResumeFn = {
+  <R, E, A>(self: Effect<R, E, A>): EffectGen<R, E, A>
+  <A, _R, _E, _A>(a: A, ab: (a: A) => Effect<_R, _E, _A>): EffectGen<_R, _E, _A>
+  <A, B, _R, _E, _A>(a: A, ab: (a: A) => B, bc: (b: B) => Effect<_R, _E, _A>): EffectGen<_R, _E, _A>
+  <A, B, C, _R, _E, _A>(a: A, ab: (a: A) => B, bc: (b: B) => C, cd: (c: C) => Effect<_R, _E, _A>): EffectGen<_R, _E, _A>
+  <A, B, C, D, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: F) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (g: H) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => P,
+    pq: (p: P) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => P,
+    pq: (p: P) => Q,
+    qr: (q: Q) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => P,
+    pq: (p: P) => Q,
+    qr: (q: Q) => R,
+    rs: (r: R) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => P,
+    pq: (p: P) => Q,
+    qr: (q: Q) => R,
+    rs: (r: R) => S,
+    st: (s: S) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+  <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, _R, _E, _A>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+    jk: (j: J) => K,
+    kl: (k: K) => L,
+    lm: (l: L) => M,
+    mn: (m: M) => N,
+    no: (n: N) => O,
+    op: (o: O) => P,
+    pq: (p: P) => Q,
+    qr: (q: Q) => R,
+    rs: (r: R) => S,
+    st: (s: S) => T,
+    tu: (s: T) => Effect<_R, _E, _A>
+  ): EffectGen<_R, _E, _A>
+}
+
 /**
  * @since 1.0.0
  * @category constructors
  */
 export const gen: <Eff extends EffectGen<any, any, any>, AEff>(
-  f: (resume: <R, E, A>(self: Effect<R, E, A>) => EffectGen<R, E, A>) => Generator<Eff, AEff, any>
+  f: (resume: ResumeFn) => Generator<Eff, AEff, any>
 ) => Effect<
   [Eff] extends [never] ? never : [Eff] extends [EffectGen<infer R, any, any>] ? R : never,
   [Eff] extends [never] ? never : [Eff] extends [EffectGen<any, infer E, any>] ? E : never,

--- a/src/internal_effect_untraced/effect.ts
+++ b/src/internal_effect_untraced/effect.ts
@@ -1169,7 +1169,11 @@ class EffectGen {
 export const gen: typeof Effect.gen = Debug.methodWithTrace((trace, restore) =>
   (f) =>
     core.suspend(() => {
-      const iterator = restore(() => f((self) => new EffectGen(self) as any))()
+      const iterator = restore(() =>
+        f((...args: [Effect.Effect<unknown, unknown, unknown>]) => {
+          return new EffectGen(pipe(...(args))) as any
+        })
+      )()
       const state = restore(() => iterator.next())()
       const run = (
         state: IteratorYieldResult<any> | IteratorReturnResult<any>

--- a/test/Effect/error-handling.ts
+++ b/test/Effect/error-handling.ts
@@ -607,12 +607,12 @@ describe.concurrent("Effect", () => {
   it.effect("tryCatch = handles exceptions", () =>
     Effect.gen(function*($) {
       const message = "hello"
-      const result = yield* $(pipe(
+      const result = yield* $(
         Effect.attemptCatch(() => {
           throw message
         }, identity),
         Effect.exit
-      ))
+      )
       assert.deepStrictEqual(Exit.unannotate(result), Exit.fail(message))
     }))
   it.effect("uncaught - fail", () =>


### PR DESCRIPTION
I am trying implement pipeable resume to improve DX 
```ts
yield* $(pipe(A, B, C))
// to just
yield* $(A, B, C)
```
But I faced with problem that I don't know how to solve(
You can look at [broken test](https://github.com/Effect-TS/io/compare/main...KhraksMamtsov:io:pipeable-resume-function?expand=1#diff-433c080a47dd5ff8679094b84e5ace4ea3ef50aedbc642209b651cb902ae4d4cL610)
I don't know how to change [`gen`](https://github.com/Effect-TS/io/compare/main...KhraksMamtsov:io:pipeable-resume-function?expand=1#diff-cf07f2ffad24699f65a9d7083ba3036f5fa7f51e40f735560041454c4af2f310R1169) function because it looks like `pipe(...args)` should be run outside traced context (???)
Help wanted)