### PR TITLE
Fix nesting for `ConfigProvider.orElse`

### DIFF
--- a/.changeset/grumpy-wombats-peel.md
+++ b/.changeset/grumpy-wombats-peel.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+fix nesting for `ConfigProvider.orElse`

--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -1,0 +1,16 @@
+{
+  "Gen": {
+    "prefix": "gg",
+    "body": [
+      "Effect.gen(function*(_) {",
+      "  $0",
+      "})"
+    ],
+    "description": "Begins an Effect.gen syntax block"
+  },
+  "Yield": {
+    "prefix": "yy",
+    "body": ["const $1 = yield* _($0)"],
+    "description": "Yields a value from a generator"
+  }
+}

--- a/src/internal_effect_untraced/configProvider.ts
+++ b/src/internal_effect_untraced/configProvider.ts
@@ -534,10 +534,10 @@ const orElseFlat = (
                     return core.fail(configError.And(left.left, right.left))
                   }
                   if (Either.isLeft(left) && Either.isRight(right)) {
-                    return core.fail(left.left)
+                    return core.succeed(right.right)
                   }
                   if (Either.isRight(left) && Either.isLeft(right)) {
-                    return core.fail(right.left)
+                    return core.succeed(left.right)
                   }
                   if (Either.isRight(left) && Either.isRight(right)) {
                     return core.succeed(pipe(left.right, HashSet.union(right.right)))


### PR DESCRIPTION
This PR fixes `ConfigProvider.orElse` which currently doesn't work with combination of nesting and indexed data.