### PR TITLE
Change doc from referencing tryCatchPromise into tryPromise

### DIFF
--- a/.changeset/yellow-carpets-end.md
+++ b/.changeset/yellow-carpets-end.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Change doc from referencing tryCatchPromise into tryPromise

--- a/docs/modules/Effect.ts.md
+++ b/docs/modules/Effect.ts.md
@@ -1399,7 +1399,7 @@ Added in v1.0.0
 
 ## promise
 
-Like `tryCatchPromise` but produces a defect in case of errors.
+Like `tryPromise` but produces a defect in case of errors.
 
 **Signature**
 

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1350,7 +1350,7 @@ export const never: Effect<never, never, never> = core.never
 export const none: <R, E, A>(self: Effect<R, E, Option.Option<A>>) => Effect<R, Option.Option<E>, void> = effect.none
 
 /**
- * Like `tryCatchPromise` but produces a defect in case of errors.
+ * Like `tryPromise` but produces a defect in case of errors.
  *
  * @since 1.0.0
  * @category constructors


### PR DESCRIPTION
as title mentions, the docs reference `tryCatchPromise` which has
merged with `tryPromise` and got removed
