### PR TITLE
add optionFromOptional

### DIFF
--- a/.changeset/angry-jars-begin.md
+++ b/.changeset/angry-jars-begin.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+add optionFromOptional

--- a/docs/modules/Config/Error.ts.md
+++ b/docs/modules/Config/Error.ts.md
@@ -27,6 +27,7 @@ Added in v1.0.0
   - [ConfigErrorReducer (interface)](#configerrorreducer-interface)
   - [InvalidData (interface)](#invaliddata-interface)
   - [MissingData (interface)](#missingdata-interface)
+  - [Options (interface)](#options-interface)
   - [Or (interface)](#or-interface)
   - [SourceUnavailable (interface)](#sourceunavailable-interface)
   - [Unsupported (interface)](#unsupported-interface)
@@ -64,7 +65,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const InvalidData: (path: Array<string>, message: string) => ConfigError
+export declare const InvalidData: (path: Array<string>, message: string, options?: Options) => ConfigError
 ```
 
 Added in v1.0.0
@@ -74,7 +75,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const MissingData: (path: Array<string>, message: string) => ConfigError
+export declare const MissingData: (path: Array<string>, message: string, options?: Options) => ConfigError
 ```
 
 Added in v1.0.0
@@ -97,7 +98,8 @@ Added in v1.0.0
 export declare const SourceUnavailable: (
   path: Array<string>,
   message: string,
-  cause: Cause.Cause<unknown>
+  cause: Cause.Cause<unknown>,
+  options?: Options
 ) => ConfigError
 ```
 
@@ -108,7 +110,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Unsupported: (path: Array<string>, message: string) => ConfigError
+export declare const Unsupported: (path: Array<string>, message: string, options?: Options) => ConfigError
 ```
 
 Added in v1.0.0
@@ -196,6 +198,18 @@ export interface MissingData extends ConfigError.Proto {
   readonly _tag: 'MissingData'
   readonly path: Array<string>
   readonly message: string
+}
+```
+
+Added in v1.0.0
+
+## Options (interface)
+
+**Signature**
+
+```ts
+export interface Options {
+  pathDelim: string
 }
 ```
 

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1352,15 +1352,6 @@ export const succeedNone: Effect<never, never, Option.Option<never>> = effect.su
 export const succeedSome: <A>(value: A) => Effect<never, never, Option.Option<A>> = effect.succeedSome
 
 /**
- * Catches all Cause.NoSuchElementExceptions that are thrown.
- * @since 1.0.0
- * @category error handling
- */
-export const catchNoSuchElement: <R, E, A>(
-  self: Effect<R, E | Cause.NoSuchElementException, A>
-) => Effect<R, E, Option.Option<A>> = effect.catchNoSuchElement
-
-/**
  * @since 1.0.0
  * @category constructors
  */
@@ -1549,7 +1540,10 @@ export const catchTag: {
 export const catchTags: {
   <
     E,
-    Cases extends (E extends { _tag: string } ? { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) } : {})
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
+        : {})
   >(
     cases: Cases
   ): <R, A>(
@@ -1572,7 +1566,10 @@ export const catchTags: {
     R,
     E,
     A,
-    Cases extends (E extends { _tag: string } ? { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) } : {})
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
+        : {})
   >(
     self: Effect<R, E, A>,
     cases: Cases
@@ -3225,6 +3222,17 @@ export const intoDeferred: {
  * @category conversions
  */
 export const option: <R, E, A>(self: Effect<R, E, A>) => Effect<R, never, Option.Option<A>> = effect.option
+
+/**
+ * Wraps the success value of this effect with `Option.some`, and maps
+ * `Cause.NoSuchElementException` to `Option.none`.
+ *
+ * @since 1.0.0
+ * @category conversions
+ */
+export const optionFromOptional: <R, E, A>(
+  self: Effect<R, E, A>
+) => Effect<R, Exclude<E, Cause.NoSuchElementException>, Option.Option<A>> = effect.optionFromOptional
 
 /**
  * Converts an option on values into an option on errors.

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1352,6 +1352,15 @@ export const succeedNone: Effect<never, never, Option.Option<never>> = effect.su
 export const succeedSome: <A>(value: A) => Effect<never, never, Option.Option<A>> = effect.succeedSome
 
 /**
+ * Catches all Cause.NoSuchElementExceptions that are thrown.
+ * @since 1.0.0
+ * @category error handling
+ */
+export const catchNoSuchElement: <R, E, A>(
+  self: Effect<R, E | Cause.NoSuchElementException, A>
+) => Effect<R, E, Option.Option<A>> = effect.catchNoSuchElement
+
+/**
  * @since 1.0.0
  * @category constructors
  */

--- a/src/internal/effect.ts
+++ b/src/internal/effect.ts
@@ -1329,6 +1329,15 @@ export const succeedSome = <A>(value: A): Effect.Effect<never, never, Option.Opt
   core.succeed(Option.some(value))
 
 /* @internal */
+export const catchNoSuchElement = <R, E, A>(
+  self: Effect.Effect<R, E | Cause.NoSuchElementException, A>
+): Effect.Effect<R, E, Option.Option<A>> =>
+  core.catchAll(
+    core.map(self, Option.some),
+    (error) => internalCause.isNoSuchElementException(error) ? succeedNone : core.fail(error as E)
+  )
+
+/* @internal */
 export const summarized = dual<
   <R2, E2, B, C>(
     summary: Effect.Effect<R2, E2, B>,

--- a/src/internal/effect.ts
+++ b/src/internal/effect.ts
@@ -1329,12 +1329,15 @@ export const succeedSome = <A>(value: A): Effect.Effect<never, never, Option.Opt
   core.succeed(Option.some(value))
 
 /* @internal */
-export const catchNoSuchElement = <R, E, A>(
-  self: Effect.Effect<R, E | Cause.NoSuchElementException, A>
-): Effect.Effect<R, E, Option.Option<A>> =>
+export const optionFromOptional = <R, E, A>(
+  self: Effect.Effect<R, E, A>
+): Effect.Effect<R, Exclude<E, Cause.NoSuchElementException>, Option.Option<A>> =>
   core.catchAll(
     core.map(self, Option.some),
-    (error) => internalCause.isNoSuchElementException(error) ? succeedNone : core.fail(error as E)
+    (error) =>
+      internalCause.isNoSuchElementException(error) ?
+        succeedNone :
+        core.fail(error as Exclude<E, Cause.NoSuchElementException>)
   )
 
 /* @internal */


### PR DESCRIPTION
This is a recurring helper I keep writing to be able to zoom "in" on the optionality of some `Effect<R, E, Option<A>>` (usually more than one), usually with `Effect.flatten` resulting in `Effect<R, E | Cause.NoSuchElementException, A>`. This is really nice for working with optionality within an Effect-based workflow, but there is not built-in for the "reverse" operation. 

I'm 110% open to bikeshedding on a better name for this operator, but this seems like a gap in the interop with Option.