### PR TITLE
feat: extended setConfigProvider

### DIFF
--- a/.changeset/blue-donkeys-pay.md
+++ b/.changeset/blue-donkeys-pay.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+extended Effect.setConfigProvider to use Effects

--- a/dtslint/Effect.ts
+++ b/dtslint/Effect.ts
@@ -1,6 +1,7 @@
 import { pipe } from "@effect/data/Function"
 import type { Cause } from "@effect/io/Cause"
 import * as Effect from "@effect/io/Effect"
+import * as ConfigProvider from "@effect/io/Config/Provider"
 
 declare const string: Effect.Effect<"dep-1", "err-1", string>
 declare const number: Effect.Effect<"dep-2", "err-2", number>
@@ -389,3 +390,9 @@ pipe(
   Effect.fail(new TestError1()),
   Effect.tapErrorTag("TestError1", () => Effect.fail(new Error("")))
 )
+
+// $ExpectType Layer<never, never, never>
+Effect.setConfigProvider(Effect.sync(() => ConfigProvider.fromEnv()))
+
+// $ExpectType Layer<never, Error, never>
+Effect.setConfigProvider(1 === 1 ? Effect.sync(() => ConfigProvider.fromEnv()) : Effect.fail(new Error("")))

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -2885,7 +2885,10 @@ export const configProviderWith: <R, E, A>(f: (configProvider: ConfigProvider) =
  * @since 1.0.0
  * @category config
  */
-export const setConfigProvider: (configProvider: ConfigProvider) => Layer.Layer<never, never, never> =
+export const setConfigProvider:{
+  <R = never, E = never>(configProvider: ConfigProvider): Layer.Layer<R, E, never>
+  <R, E>(configProviderEffect: Effect<R, E, ConfigProvider>): Layer.Layer<R, E, never>
+} =
   circularLayer.setConfigProvider
 
 /**

--- a/test/Effect/config.ts
+++ b/test/Effect/config.ts
@@ -1,0 +1,31 @@
+import * as Config from "@effect/io/Config"
+import * as ConfigProvider from "@effect/io/Config/Provider"
+import * as Effect from "@effect/io/Effect"
+import * as it from "@effect/io/test/utils/extend"
+
+const mockConfigProvider = ConfigProvider.fromMap(
+  new Map([
+    ["HOST", "localhost"],
+    ["PORT", "8080"]
+  ])
+)
+
+describe("Effect", () => {
+  it.effect("setConfigProvider/ value", () =>
+    Effect.gen(function*($) {
+      const val = yield* $(
+        Effect.config(Config.string("HOST")),
+        Effect.provideLayer(Effect.setConfigProvider(mockConfigProvider))
+      )
+      assert.deepStrictEqual(val, "localhost")
+    }))
+
+  it.effect("setConfigProvider/ effect", () =>
+    Effect.gen(function*($) {
+      const val = yield* $(
+        Effect.config(Config.string("HOST")),
+        Effect.provideLayer(Effect.setConfigProvider(Effect.sync(() => mockConfigProvider)))
+      )
+      assert.deepStrictEqual(val, "localhost")
+    }))
+})


### PR DESCRIPTION
Extends Effect.setConfigProvider to accept either `Effect<, , ConfigProvider>` or `ConfigProvider` as an argument.  Closes #589