### PR TITLE
remove double pipes

### DIFF
--- a/examples/order.ts
+++ b/examples/order.ts
@@ -77,7 +77,7 @@ const program = Effect.gen(function*($) {
   const layer3 = makeLayer3(ref)
   const env = pipe(layer1, Layer.provide(layer2), Layer.merge(pipe(layer1, Layer.provide(layer3))), Layer.build)
   yield* $(Effect.scoped(env))
-  const result = yield* $(pipe(Ref.get(ref), Effect.map((chunk) => Array.from(chunk))))
+  const result = yield* $(Ref.get(ref), Effect.map((chunk) => Array.from(chunk)))
   console.log(result)
 })
 

--- a/src/internal/effect.ts
+++ b/src/internal/effect.ts
@@ -52,9 +52,9 @@ export const annotateLogs = dual<
     return core.fiberRefLocallyWith(
       args[0] as Effect.Effect<R, E, A>,
       core.currentLogAnnotations,
-      typeof args[1] === "string" ?
-        HashMap.set(args[1], args[2]) :
-        (annotations) =>
+      typeof args[1] === "string"
+        ? HashMap.set(args[1], args[2])
+        : (annotations) =>
           Object.entries(args[1] as Record<string, Logger.AnnotationValue>).reduce(
             (acc, [key, value]) => HashMap.set(acc, key, value),
             annotations
@@ -342,9 +342,9 @@ export const descriptorWith = <R, E, A>(
 /* @internal */
 export const allowInterrupt: Effect.Effect<never, never, void> = descriptorWith(
   (descriptor) =>
-    HashSet.size(descriptor.interruptors) > 0 ?
-      core.interrupt :
-      core.unit
+    HashSet.size(descriptor.interruptors) > 0
+      ? core.interrupt
+      : core.unit
 )
 
 /* @internal */
@@ -780,9 +780,9 @@ export const gen: typeof Effect.gen = (f) =>
     const state = iterator.next()
     const run = (
       state: IteratorYieldResult<any> | IteratorReturnResult<any>
-    ): Effect.Effect<any, any, any> => (state.done ?
-      core.succeed(state.value) :
-      pipe(
+    ): Effect.Effect<any, any, any> => (state.done
+      ? core.succeed(state.value)
+      : pipe(
         state.value.value as unknown as Effect.Effect<any, any, any>,
         core.flatMap((val: any) => run(iterator.next(val)))
       ))
@@ -961,9 +961,9 @@ export const loop: {
     readonly discard?: boolean
   }
 ): Effect.Effect<R, E, Array<A>> | Effect.Effect<R, E, void> =>
-  options.discard ?
-    loopDiscard(initial, options.while, options.step, options.body) :
-    core.map(loopInternal(initial, options.while, options.step, options.body), (x) => Array.from(x))
+  options.discard
+    ? loopDiscard(initial, options.while, options.step, options.body)
+    : core.map(loopInternal(initial, options.while, options.step, options.body), (x) => Array.from(x))
 
 const loopInternal = <Z, R, E, A>(
   initial: Z,
@@ -1140,13 +1140,13 @@ export const patchFiberRefs = (patch: FiberRefsPatch.FiberRefsPatch): Effect.Eff
 
 /* @internal */
 export const promise = <A>(evaluate: (signal: AbortSignal) => Promise<A>): Effect.Effect<never, never, A> =>
-  evaluate.length >= 1 ?
-    core.async<never, never, A>((resolve, signal) => {
+  evaluate.length >= 1
+    ? core.async<never, never, A>((resolve, signal) => {
       evaluate(signal)
         .then((a) => resolve(core.exitSucceed(a)))
         .catch((e) => resolve(core.exitDie(e)))
-    }) :
-    core.async<never, never, A>((resolve) => {
+    })
+    : core.async<never, never, A>((resolve) => {
       ;(evaluate as LazyArg<Promise<A>>)()
         .then((a) => resolve(core.exitSucceed(a)))
         .catch((e) => resolve(core.exitDie(e)))
@@ -1287,9 +1287,9 @@ export const repeatN = dual<
 /* @internal */
 const repeatNLoop = <R, E, A>(self: Effect.Effect<R, E, A>, n: number): Effect.Effect<R, E, A> =>
   core.flatMap(self, (a) =>
-    n <= 0 ?
-      core.succeed(a) :
-      core.zipRight(core.yieldNow(), repeatNLoop(self, n - 1)))
+    n <= 0
+      ? core.succeed(a)
+      : core.zipRight(core.yieldNow(), repeatNLoop(self, n - 1)))
 
 /* @internal */
 export const sandbox = <R, E, A>(self: Effect.Effect<R, E, A>): Effect.Effect<R, Cause.Cause<E>, A> =>
@@ -1680,9 +1680,9 @@ export const tryMapPromise = dual<
 ): Effect.Effect<R, E | E1, B> =>
   core.flatMap(self, (a) =>
     tryPromise({
-      try: options.try.length >= 1 ?
-        (signal) => options.try(a, signal) :
-        () => (options.try as (a: A) => Promise<B>)(a),
+      try: options.try.length >= 1
+        ? (signal) => options.try(a, signal)
+        : () => (options.try as (a: A) => Promise<B>)(a),
       catch: options.catch
     })))
 
@@ -1692,9 +1692,9 @@ export const unless = dual<
   <R, E, A>(self: Effect.Effect<R, E, A>, predicate: LazyArg<boolean>) => Effect.Effect<R, E, Option.Option<A>>
 >(2, (self, predicate) =>
   core.suspend(() =>
-    predicate() ?
-      succeedNone :
-      asSome(self)
+    predicate()
+      ? succeedNone
+      : asSome(self)
   ))
 
 /* @internal */
@@ -1750,9 +1750,9 @@ export const when = dual<
   <R, E, A>(self: Effect.Effect<R, E, A>, predicate: LazyArg<boolean>) => Effect.Effect<R, E, Option.Option<A>>
 >(2, (self, predicate) =>
   core.suspend(() =>
-    predicate() ?
-      core.map(self, Option.some) :
-      core.succeed(Option.none())
+    predicate()
+      ? core.map(self, Option.some)
+      : core.succeed(Option.none())
   ))
 
 /* @internal */
@@ -1770,9 +1770,9 @@ export const whenFiberRef = dual<
   3,
   <R, E, A, S>(self: Effect.Effect<R, E, A>, fiberRef: FiberRef.FiberRef<S>, predicate: Predicate.Predicate<S>) =>
     core.flatMap(core.fiberRefGet(fiberRef), (s) =>
-      predicate(s) ?
-        core.map(self, (a) => [s, Option.some(a)] as const) :
-        core.succeed<[S, Option.Option<A>]>([s, Option.none()]))
+      predicate(s)
+        ? core.map(self, (a) => [s, Option.some(a)] as const)
+        : core.succeed<[S, Option.Option<A>]>([s, Option.none()]))
 )
 
 /* @internal */
@@ -1790,9 +1790,9 @@ export const whenRef = dual<
   3,
   <R, E, A, S>(self: Effect.Effect<R, E, A>, ref: Ref.Ref<S>, predicate: Predicate.Predicate<S>) =>
     core.flatMap(Ref.get(ref), (s) =>
-      predicate(s) ?
-        core.map(self, (a) => [s, Option.some(a)] as const) :
-        core.succeed<[S, Option.Option<A>]>([s, Option.none()]))
+      predicate(s)
+        ? core.map(self, (a) => [s, Option.some(a)] as const)
+        : core.succeed<[S, Option.Option<A>]>([s, Option.none()]))
 )
 
 /* @internal */
@@ -1878,8 +1878,8 @@ export const annotateCurrentSpan: {
   return core.flatMap(
     currentSpan,
     (span) =>
-      span._tag === "Some" ?
-        core.sync(() => {
+      span._tag === "Some"
+        ? core.sync(() => {
           if (typeof args[0] === "string") {
             span.value.attribute(args[0], args[1])
           } else {
@@ -1887,8 +1887,8 @@ export const annotateCurrentSpan: {
               span.value.attribute(key, args[0][key])
             }
           }
-        }) :
-        core.unit
+        })
+        : core.unit
   )
 }
 
@@ -1911,9 +1911,9 @@ export const annotateSpans = dual<
     return core.fiberRefLocallyWith(
       args[0] as Effect.Effect<R, E, A>,
       core.currentTracerSpanAnnotations,
-      typeof args[1] === "string" ?
-        HashMap.set(args[1], args[2]) :
-        (annotations) =>
+      typeof args[1] === "string"
+        ? HashMap.set(args[1], args[2])
+        : (annotations) =>
           Object.entries(args[1] as Record<string, Tracer.AttributeValue>).reduce(
             (acc, [key, value]) => HashMap.set(acc, key, value),
             annotations
@@ -1981,11 +1981,11 @@ export const makeSpan = (
 ) =>
   tracerWith((tracer) =>
     core.flatMap(
-      options?.parent ?
-        succeedSome(options.parent) :
-        options?.root ?
-        succeedNone :
-        currentParentSpan,
+      options?.parent
+        ? succeedSome(options.parent)
+        : options?.root
+        ? succeedNone
+        : currentParentSpan,
       (parent) =>
         core.flatMap(
           core.fiberRefGet(core.currentTracerSpanAnnotations),
@@ -1997,10 +1997,16 @@ export const makeSpan = (
                   currentTimeNanosTracing,
                   (startTime) =>
                     core.sync(() => {
-                      const linksArray = options?.links ?
-                        [...Chunk.toReadonlyArray(links), ...options.links] :
-                        Chunk.toReadonlyArray(links)
-                      const span = tracer.span(name, parent, options?.context ?? Context.empty(), linksArray, startTime)
+                      const linksArray = options?.links
+                        ? [...Chunk.toReadonlyArray(links), ...options.links]
+                        : Chunk.toReadonlyArray(links)
+                      const span = tracer.span(
+                        name,
+                        parent,
+                        options?.context ?? Context.empty(),
+                        linksArray,
+                        startTime
+                      )
                       HashMap.forEach(annotations, (value, key) => span.attribute(key, value))
                       Object.entries(options?.attributes ?? {}).forEach(([k, v]) => span.attribute(k, v))
                       return span

--- a/test/Effect/foreign.ts
+++ b/test/Effect/foreign.ts
@@ -1,6 +1,5 @@
 import * as Context from "@effect/data/Context"
 import * as Either from "@effect/data/Either"
-import { pipe } from "@effect/data/Function"
 import * as Option from "@effect/data/Option"
 import { unify } from "@effect/data/Unify"
 import * as Cause from "@effect/io/Cause"
@@ -32,12 +31,12 @@ describe.concurrent("Foreign", () => {
     Effect.gen(function*($) {
       const a = yield* $(Either.right(10))
       const b = yield* $(Effect.either(Either.left(10)))
-      const c = yield* $(pipe(
+      const c = yield* $(
         Either.right(2),
         Effect.flatMap(
           (n) => Effect.succeed(n + 1)
         )
-      ))
+      )
       assert.deepEqual(a, 10)
       assert.deepEqual(b, Either.left(10))
       assert.deepEqual(c, 3)
@@ -46,12 +45,12 @@ describe.concurrent("Foreign", () => {
     Effect.gen(function*($) {
       const a = yield* $(Option.some(10))
       const b = yield* $(Effect.either(Option.none()))
-      const c = yield* $(pipe(
+      const c = yield* $(
         Option.some(2),
         Effect.flatMap(
           (n) => Effect.succeed(n + 1)
         )
-      ))
+      )
       assert.deepEqual(a, 10)
       assert.deepEqual(b, Either.left(Cause.NoSuchElementException()))
       assert.deepEqual(c, 3)

--- a/test/ScopedCache.ts
+++ b/test/ScopedCache.ts
@@ -43,7 +43,7 @@ describe.concurrent("ScopedCache", () => {
             capacity,
             timeToLive: Duration.infinity
           })
-          const { hits, misses, size } = yield* $(pipe(
+          const { hits, misses, size } = yield* $(
             scopedCache,
             Effect.flatMap((cache) =>
               pipe(
@@ -55,7 +55,7 @@ describe.concurrent("ScopedCache", () => {
                 Effect.flatMap(() => cache.cacheStats())
               )
             )
-          ))
+          )
           expect(hits).toBe(4)
           expect(misses).toBe(6)
           expect(size).toBe(6)
@@ -148,14 +148,14 @@ describe.concurrent("ScopedCache", () => {
           { concurrency: "unbounded", discard: true }
         ))
         yield* $(cache.invalidateAll())
-        const contains = yield* $(pipe(
+        const contains = yield* $(
           Effect.forEach(
             ReadonlyArray.range(0, capacity - 1),
             (n) => Effect.scoped(cache.contains(n)),
             { concurrency: "unbounded" }
           ),
           Effect.map((_) => _.every(identity))
-        ))
+        )
         const { hits, misses, size } = yield* $(cache.cacheStats())
         yield* $(Effect.forEach(
           observablesResources,
@@ -643,10 +643,10 @@ describe.concurrent("ScopedCache", () => {
         const cache = yield* $(scopedCache)
         yield* $(Effect.scoped(cache.get(void 0)))
         yield* $(cache.refresh(void 0))
-        const createdResources = yield* $(pipe(
+        const createdResources = yield* $(
           watchableLookup.createdResources(),
           Effect.map(HashMap.unsafeGet(void 0))
-        ))
+        )
         yield* $(Chunk.unsafeHead(createdResources).assertAcquiredOnceAndCleaned())
         yield* $(Chunk.unsafeGet(createdResources, 1).assertAcquiredOnceAndNotCleaned())
       })))
@@ -763,14 +763,14 @@ describe.concurrent("ScopedCache", () => {
         yield* $(TestClock.adjust(Duration.seconds(9)))
         yield* $(watchableLookup.lock())
         const refreshFiber = yield* $(Effect.fork(cache.refresh(void 0)))
-        yield* $(pipe(
+        yield* $(
           watchableLookup.getCalledTimes(void 0),
           Effect.repeat(pipe(
             Schedule.recurWhile<number>((calledTimes) => calledTimes < 2),
             Schedule.compose(Schedule.elapsed),
             Schedule.whileOutput((elapsed) => Duration.lessThan(elapsed, Duration.millis(100)))
           ))
-        ))
+        )
         yield* $(TestServices.provideLive(Effect.sleep(Duration.millis(100))))
         yield* $(watchableLookup.assertCalledTimes(void 0, (n) => expect(n).toBe(2)))
         const firstCreatedResource = yield* $(watchableLookup.firstCreatedResource(void 0))
@@ -794,14 +794,14 @@ describe.concurrent("ScopedCache", () => {
         yield* $(TestClock.adjust(Duration.seconds(11)))
         yield* $(watchableLookup.lock())
         const refreshFiber = yield* $(Effect.fork(cache.refresh(void 0)))
-        yield* $(pipe(
+        yield* $(
           watchableLookup.getCalledTimes(void 0),
           Effect.repeat(pipe(
             Schedule.recurWhile<number>((calledTimes) => calledTimes < 1),
             Schedule.compose(Schedule.elapsed),
             Schedule.whileOutput((elapsed) => Duration.lessThan(elapsed, Duration.millis(100)))
           ))
-        ))
+        )
         yield* $(TestServices.provideLive(Effect.sleep(Duration.millis(100))))
         yield* $(watchableLookup.assertCalledTimes(void 0, (n) => expect(n).toBe(2)))
         yield* $(watchableLookup.assertFirstNCreatedResourcesCleaned(void 0, 1))

--- a/test/utils/cache/WatchableLookup.ts
+++ b/test/utils/cache/WatchableLookup.ts
@@ -62,11 +62,11 @@ export const makeEffect = <Key, Error, Value>(
             Schedule.recurWhile<boolean>(identity),
             Schedule.exponential(Duration.millis(10), 2.0)
           )
-          yield* $(pipe(
+          yield* $(
             Ref.get(blocked),
             Effect.repeat(schedule),
             TestServices.provideLive
-          ))
+          )
           return observableResource.scoped
         }))
       }


### PR DESCRIPTION
... just some house keeping.

This removes all the redundant pipe() calls.