### PR TITLE
Avoid losing annotations when catchTag / catchTags fail to recover

### DIFF
--- a/.changeset/metal-forks-nail.md
+++ b/.changeset/metal-forks-nail.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Avoid losing annotations when catchTag / catchTags fail to recover


### PR DESCRIPTION
closes #625 