### PR TITLE
Use less strict signatures in Exit module

### DIFF
--- a/.changeset/mean-geckos-hunt.md
+++ b/.changeset/mean-geckos-hunt.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+change signature Exit functions

--- a/docs/modules/Exit.ts.md
+++ b/docs/modules/Exit.ts.md
@@ -226,13 +226,13 @@ Added in v1.0.0
 
 ```ts
 export declare const match: {
-  <E, A, Z>(options: { readonly onFailure: (cause: Cause.Cause<E>) => Z; readonly onSuccess: (a: A) => Z }): (
+  <E, A, Z1, Z2>(options: { readonly onFailure: (cause: Cause.Cause<E>) => Z1; readonly onSuccess: (a: A) => Z2 }): (
     self: Exit<E, A>
-  ) => Z
-  <E, A, Z>(
+  ) => Z1 | Z2
+  <E, A, Z1, Z2>(
     self: Exit<E, A>,
-    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z; readonly onSuccess: (a: A) => Z }
-  ): Z
+    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z1; readonly onSuccess: (a: A) => Z2 }
+  ): Z1 | Z2
 }
 ```
 
@@ -247,7 +247,7 @@ export declare const matchEffect: {
   <E, A, R, E2, A2, R2, E3, A3>(options: {
     readonly onFailure: (cause: Cause.Cause<E>) => Effect.Effect<R, E2, A2>
     readonly onSuccess: (a: A) => Effect.Effect<R2, E3, A3>
-  }): (self: Exit<E, A>) => Effect.Effect<R | R2, E3, A3>
+  }): (self: Exit<E, A>) => Effect.Effect<R | R2, E2 | E3, A2 | A3>
   <E, A, R, E2, A2, R2, E3, A3>(
     self: Exit<E, A>,
     options: {
@@ -285,8 +285,8 @@ alternate `A` value computed from the specified function which receives the
 
 ```ts
 export declare const getOrElse: {
-  <E, A>(orElse: (cause: Cause.Cause<E>) => A): (self: Exit<E, A>) => A
-  <E, A>(self: Exit<E, A>, orElse: (cause: Cause.Cause<E>) => A): A
+  <E, A2>(orElse: (cause: Cause.Cause<E>) => A2): <A1>(self: Exit<E, A1>) => A2 | A1
+  <E, A1, A2>(self: Exit<E, A1>, orElse: (cause: Cause.Cause<E>) => A2): A1 | A2
 }
 ```
 

--- a/src/Exit.ts
+++ b/src/Exit.ts
@@ -247,7 +247,7 @@ export const fromOption: <A>(option: Option.Option<A>) => Exit<void, A> = core.e
  * @category getters
  */
 export const getOrElse: {
-  <E, A1, A2>(orElse: (cause: Cause.Cause<E>) => A2): (self: Exit<E, A1>) => A1 | A2
+  <E, A2>(orElse: (cause: Cause.Cause<E>) => A2): <A1>(self: Exit<E, A1>) => A1 | A2
   <E, A1, A2>(self: Exit<E, A1>, orElse: (cause: Cause.Cause<E>) => A2): A1 | A2
 } = core.exitGetOrElse
 

--- a/src/Exit.ts
+++ b/src/Exit.ts
@@ -247,8 +247,8 @@ export const fromOption: <A>(option: Option.Option<A>) => Exit<void, A> = core.e
  * @category getters
  */
 export const getOrElse: {
-  <E, A>(orElse: (cause: Cause.Cause<E>) => A): (self: Exit<E, A>) => A
-  <E, A>(self: Exit<E, A>, orElse: (cause: Cause.Cause<E>) => A): A
+  <E, A1, A2>(orElse: (cause: Cause.Cause<E>) => A2): (self: Exit<E, A1>) => A1 | A2
+  <E, A1, A2>(self: Exit<E, A1>, orElse: (cause: Cause.Cause<E>) => A2): A1 | A2
 } = core.exitGetOrElse
 
 /**
@@ -318,13 +318,13 @@ export const mapErrorCause: {
  * @category folding
  */
 export const match: {
-  <E, A, Z>(
-    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z; readonly onSuccess: (a: A) => Z }
-  ): (self: Exit<E, A>) => Z
-  <E, A, Z>(
+  <E, A, Z1, Z2>(
+    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z1; readonly onSuccess: (a: A) => Z2 }
+  ): (self: Exit<E, A>) => Z1 | Z2
+  <E, A, Z1, Z2>(
     self: Exit<E, A>,
-    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z; readonly onSuccess: (a: A) => Z }
-  ): Z
+    options: { readonly onFailure: (cause: Cause.Cause<E>) => Z1; readonly onSuccess: (a: A) => Z2 }
+  ): Z1 | Z2
 } = core.exitMatch
 
 /**
@@ -337,7 +337,7 @@ export const matchEffect: {
       readonly onFailure: (cause: Cause.Cause<E>) => Effect.Effect<R, E2, A2>
       readonly onSuccess: (a: A) => Effect.Effect<R2, E3, A3>
     }
-  ): (self: Exit<E, A>) => Effect.Effect<R | R2, E3, A3>
+  ): (self: Exit<E, A>) => Effect.Effect<R | R2, E2 | E3, A2 | A3>
   <E, A, R, E2, A2, R2, E3, A3>(
     self: Exit<E, A>,
     options: {

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -2254,8 +2254,8 @@ export const exitFromOption = <A>(option: Option.Option<A>): Exit.Exit<void, A> 
 
 /** @internal */
 export const exitGetOrElse = dual<
-  <E, A>(orElse: (cause: Cause.Cause<E>) => A) => (self: Exit.Exit<E, A>) => A,
-  <E, A>(self: Exit.Exit<E, A>, orElse: (cause: Cause.Cause<E>) => A) => A
+  <E, A1, A2>(orElse: (cause: Cause.Cause<E>) => A2) => (self: Exit.Exit<E, A1>) => A1 | A2,
+  <E, A1, A2>(self: Exit.Exit<E, A1>, orElse: (cause: Cause.Cause<E>) => A2) => A1 | A2
 >(2, (self, orElse) => {
   switch (self._tag) {
     case OpCodes.OP_FAILURE: {
@@ -2344,14 +2344,14 @@ export const exitMapErrorCause = dual<
 
 /** @internal */
 export const exitMatch = dual<
-  <E, A, Z>(options: {
-    readonly onFailure: (cause: Cause.Cause<E>) => Z
-    readonly onSuccess: (a: A) => Z
-  }) => (self: Exit.Exit<E, A>) => Z,
-  <E, A, Z>(self: Exit.Exit<E, A>, options: {
-    readonly onFailure: (cause: Cause.Cause<E>) => Z
-    readonly onSuccess: (a: A) => Z
-  }) => Z
+  <E, A, Z1, Z2>(options: {
+    readonly onFailure: (cause: Cause.Cause<E>) => Z1
+    readonly onSuccess: (a: A) => Z2
+  }) => (self: Exit.Exit<E, A>) => Z1 | Z2,
+  <E, A, Z1, Z2>(self: Exit.Exit<E, A>, options: {
+    readonly onFailure: (cause: Cause.Cause<E>) => Z1
+    readonly onSuccess: (a: A) => Z2
+  }) => Z1 | Z2
 >(2, (self, { onFailure, onSuccess }) => {
   switch (self._tag) {
     case OpCodes.OP_FAILURE: {
@@ -2370,7 +2370,7 @@ export const exitMatchEffect = dual<
       readonly onFailure: (cause: Cause.Cause<E>) => Effect.Effect<R, E2, A2>
       readonly onSuccess: (a: A) => Effect.Effect<R2, E3, A3>
     }
-  ) => (self: Exit.Exit<E, A>) => Effect.Effect<R | R2, E3 | E3, A3 | A3>,
+  ) => (self: Exit.Exit<E, A>) => Effect.Effect<R | R2, E2 | E3, A2 | A3>,
   <E, A, R, E2, A2, R2, E3, A3>(
     self: Exit.Exit<E, A>,
     options: {

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -2254,7 +2254,7 @@ export const exitFromOption = <A>(option: Option.Option<A>): Exit.Exit<void, A> 
 
 /** @internal */
 export const exitGetOrElse = dual<
-  <E, A1, A2>(orElse: (cause: Cause.Cause<E>) => A2) => (self: Exit.Exit<E, A1>) => A1 | A2,
+  <E, A2>(orElse: (cause: Cause.Cause<E>) => A2) => <A1>(self: Exit.Exit<E, A1>) => A1 | A2,
   <E, A1, A2>(self: Exit.Exit<E, A1>, orElse: (cause: Cause.Cause<E>) => A2) => A1 | A2
 >(2, (self, orElse) => {
   switch (self._tag) {


### PR DESCRIPTION
- Relaxed `match` `getOrElse` and `matchEffect` signatures
- Fixed small bug in internal module with signatures