### PR TITLE
fix: Queue.offerAll curried signature

### DIFF
--- a/.changeset/good-spiders-matter.md
+++ b/.changeset/good-spiders-matter.md
@@ -1,0 +1,5 @@
+---
+"@effect/io": patch
+---
+
+Fix curried signature for Queue.offerAll

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -506,7 +506,7 @@ export const unsafeOffer: {
  * @category utils
  */
 export const offerAll: {
-  <A>(iterable: Iterable<A>): (self: Enqueue<A>) => (self: Enqueue<A>) => Effect.Effect<never, never, boolean>
+  <A>(iterable: Iterable<A>): (self: Enqueue<A>) => Effect.Effect<never, never, boolean>
   <A>(self: Enqueue<A>, iterable: Iterable<A>): Effect.Effect<never, never, boolean>
 } = internal.offerAll
 

--- a/src/internal/queue.ts
+++ b/src/internal/queue.ts
@@ -455,7 +455,7 @@ export const unsafeOffer = dual<
 export const offerAll = dual<
   <A>(
     iterable: Iterable<A>
-  ) => (self: Queue.Enqueue<A>) => (self: Queue.Enqueue<A>) => Effect.Effect<never, never, boolean>,
+  ) => (self: Queue.Enqueue<A>) => Effect.Effect<never, never, boolean>,
   <A>(
     self: Queue.Enqueue<A>,
     iterable: Iterable<A>


### PR DESCRIPTION
The curried variant of `Queue.offerAll` is type incorrectly accepting 2 separate Enqueues. This just removes the second to fix the signature.